### PR TITLE
whitespace cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ timetest
 
 src/libfaketime.dylib.1
 src/core
-

--- a/NEWS
+++ b/NEWS
@@ -5,11 +5,11 @@ Since 0.8.2:
       a program can be started regularly, and after 5 minutes run-time
       it will be sent two years into the future. Those limiting
       start and stop times can be specified in seconds or as the
-      number of any time-related function calls within the program. 
+      number of any time-related function calls within the program.
     - Added a feature to spawn an external process after x seconds
       or y time-related system calls. This can, for example, be used
       to execute an arbitrary shell script x seconds after a program
-      has been started. 
+      has been started.
 
 Since 0.8.1:
     - Added a MacOS port.
@@ -88,4 +88,3 @@ Since 0.2:
 Since 0.1:
     - Fixed segfault when calling time(NULL). Thanks to Andres Ojamaa!
     - Added additional sanity checks.
-

--- a/README
+++ b/README
@@ -27,13 +27,13 @@ Content of this file:
 1. Introduction
 ---------------
 
-FTPL intercepts various system calls which programs use to retrieve the 
-current date and time. It can then report faked dates and times (as 
+FTPL intercepts various system calls which programs use to retrieve the
+current date and time. It can then report faked dates and times (as
 specified by you, the user) to these programs. This means you can modify
 the system time a program sees without having to change the time system-
 wide.
 
-FTPL allows you to specify both absolute dates (e.g., 01/01/2004) and 
+FTPL allows you to specify both absolute dates (e.g., 01/01/2004) and
 relative dates (e.g., 10 days ago).
 
 FTPL might be used for various purposes, for example
@@ -50,12 +50,12 @@ FTPL might be used for various purposes, for example
 2. Compatibility issues
 -----------------------
 
-* FTPL has been designed on and for Linux 2.x, but is supposed and has been 
-  reported to work on other *NIXes as well. 
+* FTPL has been designed on and for Linux 2.x, but is supposed and has been
+  reported to work on other *NIXes as well.
 
 * FTPL uses the library preload mechanism and thus cannot work with statically
   linked binaries or binaries that have the setuid-flag set (e.g., suidroot
-  programs like "ping" or "passwd"). 
+  programs like "ping" or "passwd").
 
 * As of version 0.7, support has been added for use in a pthreads environment. A
   separate library is built (libfaketimeMT.so.1) which contains the pthread
@@ -79,15 +79,15 @@ FTPL might be used for various purposes, for example
 ---------------
 
 Running "make" should compile both library versions and a test program, which
-it then also executes. 
+it then also executes.
 
 If the test works fine, you should copy the FTPL libraries (libfaketime.so.1,
-and libfaketimeMT.so.1) to the place you want them in. Running "make install" 
-will attempt to place them in /usr/local/lib/faketime and will install the wrapper 
+and libfaketimeMT.so.1) to the place you want them in. Running "make install"
+will attempt to place them in /usr/local/lib/faketime and will install the wrapper
 shell script "faketime" in /usr/local/bin, both of which most likely will require
-root privileges; however, from a technical point of view, there is no 
+root privileges; however, from a technical point of view, there is no
 necessity for a system-wide installation, so you can use FTPL also on machines
-where you do not have root privileges. You may want to adjust the PREFIX 
+where you do not have root privileges. You may want to adjust the PREFIX
 variable in the Makefiles accordingly.
 
 Since version 0.6, system calls to file timestamps are also intercepted now,
@@ -139,11 +139,11 @@ Or it can be done by specifying it on the command line itself:
 
 LD_PRELOAD=/path/to/libfaketime.so.1 your_command_here
 
-(These examples are for the bash shell; how environment variables are set may 
+(These examples are for the bash shell; how environment variables are set may
 vary on your system.)
 
 
-However, also the faked time should be specified; otherwise, FTPL will be 
+However, also the faked time should be specified; otherwise, FTPL will be
 loaded, but just report the real system time. There are three ways to specify
 the faked time:
 
@@ -151,19 +151,19 @@ a) By setting the environment variable FAKETIME.
 b) By using the file .faketimerc in your home directory.
 c) By using the file /etc/faketimerc for a system-wide default.
 
-If you want to use b) or c), $HOME/.faketimerc or /etc/faketimerc consist of 
-only one line of text with exactly the same content as the FAKETIME environment 
+If you want to use b) or c), $HOME/.faketimerc or /etc/faketimerc consist of
+only one line of text with exactly the same content as the FAKETIME environment
 variable, which is described below. Note that /etc/faketimerc will only be used
 if there is no $HOME/.faketimerc, and the FAKETIME environment variable always
 has priority over the files.
 
-   
+
 4b) Using absolute dates
 ------------------------
 
-The format which _must_ be used for _absolute_ dates is "YYYY-MM-DD hh:mm:ss". 
+The format which _must_ be used for _absolute_ dates is "YYYY-MM-DD hh:mm:ss".
 For example, the 24th of December, 2002, 8:30 PM would have to be specified as
-FAKETIME="2002-12-24 20:30:00". 
+FAKETIME="2002-12-24 20:30:00".
 
 
 4c) Using 'start at' dates
@@ -171,9 +171,9 @@ FAKETIME="2002-12-24 20:30:00".
 
 (Thanks to a major contribution by David North, TDI in version 0.7)
 
-The format which _must_ be used for _start_at_ dates is "@YYYY-MM-DD hh:mm:ss". 
+The format which _must_ be used for _start_at_ dates is "@YYYY-MM-DD hh:mm:ss".
 For example, the 24th of December, 2002, 8:30 PM would have to be specified as
-FAKETIME="@2002-12-24 20:30:00". 
+FAKETIME="@2002-12-24 20:30:00".
 
 The absolute dates described in 4b simulate a STOPPED system clock at the
 specified absolute time. The 'start at' format allows a 'relative' clock
@@ -188,14 +188,14 @@ Relative date offsets can be positive or negative, thus what you put into
 FAKETIME _must_ either start with a + or a -, followed by a number, and
 optionally followed by a multiplier:
 
-- by default, the offset you specify is in seconds. Example: 
-  
+- by default, the offset you specify is in seconds. Example:
+
   export FAKETIME="-120" will set the faked time 2 minutes (120 seconds) behind
   the real time.
-  
-- the multipliers "m", "h", "d" and "y" can be used to specify the offset in 
+
+- the multipliers "m", "h", "d" and "y" can be used to specify the offset in
   minutes, hours, days and years (365 days each), respectively. Examples:
-  
+
   export FAKETIME="-10m" sets the faked time 10 minutes behind the real time.
   export FAKETIME="+14d" sets the faked time to 14 days in the future.
 
@@ -211,7 +211,7 @@ Moreno Baricevic has contributed support for the FAKETIME_FMT environment
 variable, which allows to optionally set the strptime() format:
 
 Some simple examples:
-LD_PRELOAD=./libfaketime.so.1 FAKETIME_FMT=%s FAKETIME="`date +%s -d'1 year ago'`" date 
+LD_PRELOAD=./libfaketime.so.1 FAKETIME_FMT=%s FAKETIME="`date +%s -d'1 year ago'`" date
 LD_PRELOAD=./libfaketime.so.1 FAKETIME_FMT=%s FAKETIME="`stat -c %Y somefile`" date
 LD_PRELOAD=./libfaketime.so.1 FAKETIME_FMT=%c FAKETIME="`date`" date
 
@@ -246,21 +246,21 @@ twice as fast. Similarly,
 FAKETIME="+1y x0,5"
 
 will make the clock run only half as fast. As stated above, the fraction
-delimiter depends on your locale. 
+delimiter depends on your locale.
 
 For testing, your should run a command like
 
 LD_PRELOAD=./libfaketime.so.1 FAKETIME="+1,5y x10,0" \
 /bin/bash -c 'while true; do echo $SECONDS ; sleep 1 ; done'
 
-For each second that the endless loop sleeps, the executed bash shell will 
-think that 10 seconds have passed ($SECONDS is a bash-internal variable 
+For each second that the endless loop sleeps, the executed bash shell will
+think that 10 seconds have passed ($SECONDS is a bash-internal variable
 measuring the time since the shell was started).
 
 (Please note that replacing "echo $SECONDS" e.g. with a call to "/bin/date"
 will not give the expected result, since /bin/date will always be started
 as a new process for which also FTPL will be re-initialized. It will show
-the correct offset (1.5 years in the future), but no speed-ups or 
+the correct offset (1.5 years in the future), but no speed-ups or
 slow-downs.)
 
 
@@ -278,7 +278,7 @@ for new mail every X minutes).
 
 Using relative offsets or 'start at' dates solves this problem. FTPL then will
 always report the faked time based on the real current time and the offset
-you've specified. 
+you've specified.
 
 Please also note that your specification of the fake time is cached for 10
 seconds in order to enhance the library's performance. Thus, if you change the
@@ -291,12 +291,12 @@ command line option -DNO_CACHING to this library's Makefile.
 4f) Faking the date and time system-wide
 ----------------------------------------
 
-David Burley of SourceForge, Inc. reported an interesting use case of applying 
-FTPL system-wide: Currently, all virtual machines running inside an OpenVZ host 
-have the same system date and time. In order to use multiple sandboxes with 
-different system dates, the FTPL library can be put into /etc/ld.so.preload; 
+David Burley of SourceForge, Inc. reported an interesting use case of applying
+FTPL system-wide: Currently, all virtual machines running inside an OpenVZ host
+have the same system date and time. In order to use multiple sandboxes with
+different system dates, the FTPL library can be put into /etc/ld.so.preload;
 it will then be applied to all commands and programs automatically. This is
-of course best used with a system-wide /etc/faketimerc file. Kudos to 
+of course best used with a system-wide /etc/faketimerc file. Kudos to
 SourceForge, Inc. for providing the patch!
 
 
@@ -324,7 +324,7 @@ Thanks to Daniel Kahn Gillmor for providing these suggestions!
 --------------------------
 
 Starting with version 0.9, libfaketime can be configured to not be continuously
-active, but only during a certain time interval. 
+active, but only during a certain time interval.
 
 For example, you might want to start a program with the real current time, but
 after 5 minutes of usage, you might want it to see a faked time, e.g., a year
@@ -340,7 +340,7 @@ Dynamic changes to the faked time are alternatively possible by
 - not using the FAKETIME environment variable, but specifying the fake time in a
   file (such as ~/.faketimerc). You can change the content of this file at
   run-time. This works best with caching disabled (see Makefile), but comes at a
-  performance cost because this file has to be read and evaluated each time. 
+  performance cost because this file has to be read and evaluated each time.
 
 The feature described here works based on two pairs of environment variables,
 
@@ -348,7 +348,7 @@ The feature described here works based on two pairs of environment variables,
   FAKETIME_START_AFTER_NUMCALLS and FAKETIME_STOP_AFTER_NUMCALLS
 
 The default value for each of these environment variables is -1, which means
-"ignore this value". 
+"ignore this value".
 
 If you want libfaketime to be only active during the run-time minutes 2 to 5
 of your application, you would set
@@ -359,7 +359,7 @@ of your application, you would set
 This means that your application will work with the real time from start (second
 0) up to second 60. It will then see a faked time from run-time seconds 60 to
 300 (minutes 2, 3, 4, and 5). After run-time second 600, it will again see the
-real (not-faked) time. 
+real (not-faked) time.
 
 This approach is not as flexible as changing the FAKETIME environment variable
 during runtime, but may be easier to use, works on a per-program (and not a
@@ -368,9 +368,9 @@ per-user or system-wide) scope, and has only a minor performance overhead.
 Using the other pair of environment variables, you can limit the activity time
 of libfaketime not based on wall-clock seconds, but on the number of
 time-related function calls the started program performs. This alternative is
-probably only suitable for programmers who either know the code of the program 
-in order to determine useful start/stop values or want to perform fuzzing 
-tests. 
+probably only suitable for programmers who either know the code of the program
+in order to determine useful start/stop values or want to perform fuzzing
+tests.
 
 Both pairs of environment variables can be combined to further restrict
 libfaketime activity, although this is only useful in very few scenarios.
@@ -379,9 +379,9 @@ Limiting libfaketime activity in this way is not recommended in general. Many
 programs will break when they are subject to sudden changes in time, especially
 if they are started using the current (real) time and are then sent back into
 the past after, e.g., 5 minutes. For example, they may appear to be frozen or
-stuck because they are waiting until a certain point in time that, however, is 
-never reached due to the delayed libfaketime activity. Avoid using this 
-functionality unless you are sure you really need it and know what you are 
+stuck because they are waiting until a certain point in time that, however, is
+never reached due to the delayed libfaketime activity. Avoid using this
+functionality unless you are sure you really need it and know what you are
 doing.
 
 
@@ -401,7 +401,7 @@ program started. This has two limitations one needs to be aware of:
 * The original program is blocked until the external process is finished,
   because the intercepting time-related system call will not return earlier. If
   you need to start a long-running external process, make sure it forks into the
-  background. 
+  background.
 
 Spawning the external process is controlled using three environment variables:
 FAKETIME_SPAWN_TARGET, FAKETIME_SPAWN_SECONDS, FAKETIME_SPAWN_NUMCALLS.
@@ -415,7 +415,7 @@ export FAKETIME_SPAWN_SECONDS=5
 
 This will run the "echo" command with the given parameter during the first
 time-related system function call that "myprogram" performs after running for 5
-seconds. 
+seconds.
 
 
 5. License
@@ -435,4 +435,3 @@ appreciated.
 Please send an email to: wolf /at/ code-wizards.com
 
 git pull requests are welcome, see https://github.com/wolfcw/libfaketime
-

--- a/README.OSX
+++ b/README.OSX
@@ -23,7 +23,7 @@ The resulting library will be named libfaketime.dylib.1
 2) Using libfaketime from the command line on OS X
 --------------------------------------------------
 
-You will need to set three environment variables. In a Terminal.app 
+You will need to set three environment variables. In a Terminal.app
 or iTerm session, the following commands can be used:
 
 export DYLD_FORCE_FLAT_NAMESPACE=1
@@ -59,7 +59,7 @@ following command:
 the name of your actual application.)
 
 If it works fine, you can configure the application to permanently
-run with libfaketime by editing its Info.plist file. Add the 
+run with libfaketime by editing its Info.plist file. Add the
 LSEnvironment key unless it is already there and add a dictionary
 with the three keys like this:
 
@@ -84,8 +84,8 @@ Afterwards, you will probably need to run
 
 to make sure the change to Info.plist does not go unnoticed.
 
-Please note that modifications to Info.plist will be lost when the 
-application is updated, so this process needs to be repeated after 
+Please note that modifications to Info.plist will be lost when the
+application is updated, so this process needs to be repeated after
 such updates, including own new builds when using Xcode.
 
 
@@ -95,4 +95,3 @@ such updates, including own new builds when using Xcode.
 The environment variable FAKETIME can be changed at application run-time
 and always takes precedence over other user-controlled settings. It can
 be re-set to 0 (zero) to work around potential incompatibilities.
-

--- a/TODO
+++ b/TODO
@@ -4,4 +4,3 @@ Open issues / next steps for libfaketime development
 - use the new testing framework to also implement unit tests
 - make the new "limiting" and "spawning" features more flexible to use
   and available through the wrapper shell script
-

--- a/man/faketime.1
+++ b/man/faketime.1
@@ -8,10 +8,10 @@ faketime \- manipulate the system time for a given command
 .\" \fIfaketime\fR will trick the given program into seeing the specified timestamp as its starting date and time.
 .PP
 The given command will be tricked into believing that the current system time is the one specified in the timestamp. The wall clock will continue to run
-from this date and time unless specified otherwise (see advanced options). Actually, faketime is a simple wrapper for libfaketime, which uses the LD_PRELOAD 
+from this date and time unless specified otherwise (see advanced options). Actually, faketime is a simple wrapper for libfaketime, which uses the LD_PRELOAD
 mechanism to load a small library which intercepts system calls to functions such as
 \fItime(2)\fR and \fIfstat(2)\fR. This wrapper exposes only a subset of libfaketime's functionality; please refer to the README file that came with faketime
-for more details and advanced options. 
+for more details and advanced options.
 .SH OPTIONS
 .TP
 \fB\-\-help\fR
@@ -44,21 +44,21 @@ Freeze clock at absolute timestamp: \fB"YYYY-MM-DD hh:mm:ss"\fR
 If you want to specify an absolute point in time, exactly this format must be used. Please note that freezing the clock is usually not what you want and may break the application. Only use if you know what you're doing!
 .TP
 Relative time offset: \fB"[+/-]123[m/h/d/y]\fR, e.g. "+60m", "+2y"
-This is the most often used format and specifies the faked time relatively to the current real time. The first character of the format string \fBmust\fR be a + or a -. The numeric value by default represents seconds, but the modifiers m, h, d, and y can be used to specify minutes, hours, days, or years, respectively. For example, "-2y" means "two years ago". Fractional time offsets can be used, e.g. "+2,5y", which means "two and a half years in the future". Please note that the fraction delimiter depends on your locale settings, so if "+2,5y" does not work, you might want to try "+2.5y". 
+This is the most often used format and specifies the faked time relatively to the current real time. The first character of the format string \fBmust\fR be a + or a -. The numeric value by default represents seconds, but the modifiers m, h, d, and y can be used to specify minutes, hours, days, or years, respectively. For example, "-2y" means "two years ago". Fractional time offsets can be used, e.g. "+2,5y", which means "two and a half years in the future". Please note that the fraction delimiter depends on your locale settings, so if "+2,5y" does not work, you might want to try "+2.5y".
 .TP
 Start-at timestamps: \fB"@YYYY-MM-DD hh:mm:ss"\fR
-The wall clock will start counting at the given timestamp for the program. This can be used for specifying absolute timestamps without freezing the clock. 
+The wall clock will start counting at the given timestamp for the program. This can be used for specifying absolute timestamps without freezing the clock.
 .SH ADVANCED USAGE
 When using relative time offsets or start-at timestamps (see ADVANCED TIMESTAMP FORMAT above and option \fB\-f\fR), the clock speed can be adjusted, i.e. time may run faster or slower for the executed program. For example, \fB"+5y x10"\fR will set the faked time 5 years into the future and make the time pass 10 times as fast (one real second equals 10 seconds measured by the program). Similarly, the flow of time can be slowed, e.g. using \fB"-7d x0,2"\fR, which will set the faked time 7 days in the past and set the clock speed to 20 percent, i.e. it takes five real world seconds for one second measured by the program. Again, depending on your locale, either "x2.0" or "x2,0" may be required regarding the delimiter.
 .PP
 Faking times for multiple programs or even system-wide can be simplified by using ~/.faketimerc files and /etc/faketimerc. Please refer to the README that came with faketime for warnings and details.
 .SH AUTHOR
-Maintained by Wolfgang Hommel <wolf@code-wizards.com>. Please see the README and Changelog files for contributers. 
+Maintained by Wolfgang Hommel <wolf@code-wizards.com>. Please see the README and Changelog files for contributers.
 .SH BUGS
-Due to limitations of the LD_PRELOAD mechanism, faketime will not work with suidroot and statically linked programs. 
+Due to limitations of the LD_PRELOAD mechanism, faketime will not work with suidroot and statically linked programs.
 While timestamps and time offsets will work for child processes, speeding the clock up or slowing it down might not
 work for child processes spawned by the executed program as expected; a new instance of libfaketime is used for each
-child process, which means that the libfaketime start time, which is used in speed adjustments, will also be 
+child process, which means that the libfaketime start time, which is used in speed adjustments, will also be
 re-initialized.
 .SH "REPORTING BUGS"
 Please send an e-mail to Wolfgang Hommel <wolf@code-wizards.com>

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,11 +4,11 @@
 #   * Compilation Defines:
 #
 #     FAKE_STAT
-#         - Enables time faking also for files' timestamps. 
+#         - Enables time faking also for files' timestamps.
 #
 #     NO_ATFILE
 #         - Disables support for the fstatat() group of functions
-#     
+#
 #     PTHREAD
 #         - Define this to enable multithreading support.
 #
@@ -19,16 +19,16 @@
 #           try it unsynchronized.
 #
 #     FAKE_INTERNAL_CALLS
-#         - Also intercept libc internal __functions, e.g. not just time(), 
+#         - Also intercept libc internal __functions, e.g. not just time(),
 #           but also __time(). Enhances compatibility with applications
 #           that make use of low-level system calls, such as Java Virtual
-#           Machines.       
+#           Machines.
 #
 #     NO_CACHING
 #         - Disables the caching of the fake time offset. Only disable caching
-#           if you change the fake time offset during program runtime very 
+#           if you change the fake time offset during program runtime very
 #           frequently. Disabling the cache may negatively influence the
-#           performance. 
+#           performance.
 #
 #     LIMITEDFAKING
 #		  - Support environment variables that limit time faking to certain
@@ -71,14 +71,14 @@ ${OBJ}: faketime.c
 lib%.so.${SONAME}: %.o
 	${CC} -o $@ -Wl,-soname,$@ $< ${LDFLAGS}
 
-clean: 
+clean:
 	@rm -f ${OBJ} ${LIBS}
 
 distclean: clean
-	@echo 
+	@echo
 
 install: ${LIBS}
-	@echo 
+	@echo
 	@echo "Copying the faketime libraries to ${DESTDIR}${PREFIX}/lib/faketime and the faketime wrapper script to ${DESTDIR}${PREFIX}/bin ..."
 	$(INSTALL) -dm0755 "${DESTDIR}${PREFIX}/lib/faketime/"
 	$(INSTALL) -m0644 ${LIBS} "${DESTDIR}${PREFIX}/lib/faketime/"

--- a/src/Makefile.MacOS
+++ b/src/Makefile.MacOS
@@ -4,11 +4,11 @@
 #   * Compilation Defines:
 #
 #     FAKE_STAT
-#         - Enables time faking also for files' timestamps. 
+#         - Enables time faking also for files' timestamps.
 #
 #     NO_ATFILE
 #         - Disables support for the fstatat() group of functions
-#     
+#
 #     PTHREAD
 #         - Define this to enable multithreading support.
 #
@@ -19,16 +19,16 @@
 #           try it unsynchronized.
 #
 #     FAKE_INTERNAL_CALLS
-#         - Also intercept libc internal __functions, e.g. not just time(), 
+#         - Also intercept libc internal __functions, e.g. not just time(),
 #           but also __time(). Enhances compatibility with applications
 #           that make use of low-level system calls, such as Java Virtual
-#           Machines.       
+#           Machines.
 #
 #     NO_CACHING
 #         - Disables the caching of the fake time offset. Only disable caching
-#           if you change the fake time offset during program runtime very 
+#           if you change the fake time offset during program runtime very
 #           frequently. Disabling the cache may negatively influence the
-#           performance. 
+#           performance.
 #
 #     LIMITEDFAKING
 #         - Support environment variables that limit time faking to certain
@@ -70,14 +70,14 @@ all: ${LIBS}
 libfaketime.dylib.${SONAME}: ${SRC}
 	${CC} -o $@ ${CFLAGS} $<
 
-clean: 
+clean:
 	@rm -f ${OBJ} ${LIBS}
 
 distclean: clean
-	@echo 
+	@echo
 
 install: ${LIBS}
-	@echo 
+	@echo
 	@echo "Copying the faketime libraries to ${DESTDIR}${PREFIX}/lib/faketime and the faketime wrapper script to ${DESTDIR}${PREFIX}/bin ..."
 	$(INSTALL) -dm0755 "${DESTDIR}${PREFIX}/lib/faketime/"
 	$(INSTALL) -m0644 ${LIBS} "${DESTDIR}${PREFIX}/lib/faketime/"

--- a/src/faketime
+++ b/src/faketime
@@ -1,21 +1,21 @@
 #!/bin/sh
 
 # Simple wrapper shell script for FTPL (faketime preload library)
-# Thanks to Daniel Kahn Gillmor for improvement suggestions. 
+# Thanks to Daniel Kahn Gillmor for improvement suggestions.
 
 # It allows you to modify the date and time a program sees when using
-# system library calls such as time() and fstat(). 
+# system library calls such as time() and fstat().
 
 # This wrapper exposes only a small subset of the FTPL functionality.
 # Please see FTPL's README file for more details
 
-# Acknowledgment: Parts of the functionality of this wrapper have been 
+# Acknowledgment: Parts of the functionality of this wrapper have been
 # inspired by Matthias Urlichs' datefudge 1.14.
 
 # Configuration: Path where the libfaketime libraries can be found on Linux/UNIX.
 FTPL_PATH=/usr/lib/faketime
 
-# For Mac OS X users: Full path and name to libfaketime.dylib.1 
+# For Mac OS X users: Full path and name to libfaketime.dylib.1
 MAC_FTPL_PATH=./libfaketime.dylib.1
 
 offset="$1"
@@ -87,13 +87,13 @@ fi
 
 if [ "$USEDIRECT" -eq 0 ] ; then
 	seconds=$($DATE_CMD -d "$offset" '+%s')
-	if [ $? -ne 0 ] ; then 
+	if [ $? -ne 0 ] ; then
 		echo "Error: Timestamp to fake not recognized, please re-try with a different timestamp."
-		exit 1 
+		exit 1
 	fi
 
 	offset=$(expr $seconds - $($DATE_CMD '+%s'))
-	if [ $? -ne 0 ] ; then 
+	if [ $? -ne 0 ] ; then
 		echo "Error: Cannot calculate the faketime offset in seconds, please re-try with a different timestamp."
 		exit 1
 	fi

--- a/src/faketime.c
+++ b/src/faketime.c
@@ -1,12 +1,12 @@
 /*
  *  This file is part of the FakeTime Preload Library, version 0.8.
  *
- *  The FakeTime Preload Library is free software; you can redistribute it 
- *  and/or modify it under the terms of the GNU General Public License v2 as 
+ *  The FakeTime Preload Library is free software; you can redistribute it
+ *  and/or modify it under the terms of the GNU General Public License v2 as
  *  published by the Free Software Foundation.
  *
- *  The FakeTime Preload Library is distributed in the hope that it will 
- *  be useful, but WITHOUT ANY WARRANTY; without even the implied warranty 
+ *  The FakeTime Preload Library is distributed in the hope that it will
+ *  be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
  *  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
  *
@@ -62,7 +62,7 @@ int    fake_gettimeofday(struct timeval *tv, void *tz);
 int    fake_clock_gettime(clockid_t clk_id, struct timespec *tp);
 #endif
 
-/* 
+/*
  * Intercepted system calls:
  *  - time()
  *  - ftime()
@@ -71,7 +71,7 @@ int    fake_clock_gettime(clockid_t clk_id, struct timespec *tp);
  *
  *  Since version 0.7, if FAKE_INTERNAL_CALLS is defined, also calls to
  *  __time(), __ftime(), __gettimeofday(), and __clock_gettime() will be
- *  intercepted. 
+ *  intercepted.
  *
  *  Thanks to a contribution by Philipp Hachtmann, the following
  *  system calls will also be time-adjusted depending on the compile
@@ -110,9 +110,9 @@ int __xstat (int ver, const char *path, struct stat *buf) {
     }
   END_SINGLE_IF
   if (!has_real_stat) {  /* dlsym() failed */
-#ifdef DEBUG 
+#ifdef DEBUG
     (void) fprintf(stderr, "faketime problem: original stat() not found.\n");
-#endif 
+#endif
     return -1; /* propagate error to caller */
   }
 
@@ -125,7 +125,7 @@ int __xstat (int ver, const char *path, struct stat *buf) {
      if (!fake_stat_disabled) {
        buf->st_ctime = fake_time(&(buf->st_ctime));
        buf->st_atime = fake_time(&(buf->st_atime));
-       buf->st_mtime = fake_time(&(buf->st_mtime)); 
+       buf->st_mtime = fake_time(&(buf->st_mtime));
      }
    }
 
@@ -145,9 +145,9 @@ int __fxstat (int ver, int fildes, struct stat *buf) {
     }
   END_SINGLE_IF
   if (!has_real_fstat) {  /* dlsym() failed */
-#ifdef DEBUG 
+#ifdef DEBUG
     (void) fprintf(stderr, "faketime problem: original fstat() not found.\n");
-#endif 
+#endif
     return -1; /* propagate error to caller */
   }
 
@@ -180,9 +180,9 @@ int __fxstatat(int ver, int fildes, const char *filename, struct stat *buf, int 
     }
   END_SINGLE_IF
   if (!has_real_fstatat) {  /* dlsym() failed */
-#ifdef DEBUG 
+#ifdef DEBUG
     (void) fprintf(stderr, "faketime problem: original fstatat() not found.\n");
-#endif 
+#endif
     return -1; /* propagate error to caller */
   }
 
@@ -215,9 +215,9 @@ int __lxstat (int ver, const char *path, struct stat *buf) {
     }
   END_SINGLE_IF
   if (!has_real_lstat) {  /* dlsym() failed */
-#ifdef DEBUG 
+#ifdef DEBUG
     (void) fprintf(stderr, "faketime problem: original lstat() not found.\n");
-#endif 
+#endif
     return -1; /* propagate error to caller */
   }
 
@@ -228,7 +228,7 @@ int __lxstat (int ver, const char *path, struct stat *buf) {
 
   if (buf != NULL) {
     if (!fake_stat_disabled) {
-      buf->st_ctime = fake_time(&(buf->st_ctime)); 
+      buf->st_ctime = fake_time(&(buf->st_ctime));
       buf->st_atime = fake_time(&(buf->st_atime));
       buf->st_mtime = fake_time(&(buf->st_mtime));
     }
@@ -249,9 +249,9 @@ int __xstat64 (int ver, const char *path, struct stat64 *buf) {
     }
   END_SINGLE_IF
   if (!has_real_stat) {  /* dlsym() failed */
-#ifdef DEBUG 
+#ifdef DEBUG
     (void) fprintf(stderr, "faketime problem: original stat() not found.\n");
-#endif 
+#endif
     return -1; /* propagate error to caller */
   }
 
@@ -283,9 +283,9 @@ int __fxstat64 (int ver, int fildes, struct stat64 *buf) {
     }
   END_SINGLE_IF
   if (!has_real_fstat) {  /* dlsym() failed */
-#ifdef DEBUG 
+#ifdef DEBUG
     (void) fprintf(stderr, "faketime problem: original fstat() not found.\n");
-#endif 
+#endif
     return -1; /* propagate error to caller */
   }
 
@@ -294,11 +294,11 @@ int __fxstat64 (int ver, int fildes, struct stat64 *buf) {
     return -1;
   }
 
-  if (buf != NULL){ 
+  if (buf != NULL){
     if (!fake_stat_disabled) {
-      buf->st_ctime = fake_time(&(buf->st_ctime)); 
-      buf->st_atime = fake_time(&(buf->st_atime)); 
-      buf->st_mtime = fake_time(&(buf->st_mtime)); 
+      buf->st_ctime = fake_time(&(buf->st_ctime));
+      buf->st_atime = fake_time(&(buf->st_atime));
+      buf->st_mtime = fake_time(&(buf->st_mtime));
     }
   }
   return result;
@@ -318,9 +318,9 @@ int __fxstatat64 (int ver, int fildes, const char *filename, struct stat64 *buf,
     }
   END_SINGLE_IF
   if (!has_real_fstatat64) {  /* dlsym() failed */
-#ifdef DEBUG 
+#ifdef DEBUG
     (void) fprintf(stderr, "faketime problem: original fstatat64() not found.\n");
-#endif 
+#endif
     return -1; /* propagate error to caller */
   }
 
@@ -329,11 +329,11 @@ int __fxstatat64 (int ver, int fildes, const char *filename, struct stat64 *buf,
     return -1;
   }
 
-  if (buf != NULL){ 
+  if (buf != NULL){
     if (!fake_stat_disabled) {
-      buf->st_ctime = fake_time(&(buf->st_ctime)); 
-      buf->st_atime = fake_time(&(buf->st_atime)); 
-      buf->st_mtime = fake_time(&(buf->st_mtime)); 
+      buf->st_ctime = fake_time(&(buf->st_ctime));
+      buf->st_atime = fake_time(&(buf->st_atime));
+      buf->st_mtime = fake_time(&(buf->st_mtime));
     }
   }
   return result;
@@ -364,7 +364,7 @@ int __lxstat64 (int ver, const char *path, struct stat64 *buf){
     return -1;
   }
 
-  if (buf != NULL){ 
+  if (buf != NULL){
     if (!fake_stat_disabled) {
       buf->st_ctime = fake_time(&(buf->st_ctime));
       buf->st_atime = fake_time(&(buf->st_atime));
@@ -399,14 +399,14 @@ static time_t _ftpl_time(time_t *time_tptr) {
     static time_t (*real_time)(time_t *);
     static int has_real_time = 0;
 #endif
-    
+
     time_t result;
 
     time_t null_dummy;
 
     /* Handle null pointers correctly, fix as suggested by Andres Ojamaa */
     if (time_tptr == NULL) {
-	    time_tptr = &null_dummy;    
+        time_tptr = &null_dummy;
         /* (void) fprintf(stderr, "NULL pointer caught in time().\n"); */
     }
 
@@ -415,24 +415,24 @@ static time_t _ftpl_time(time_t *time_tptr) {
     SINGLE_IF(has_real_gettimeofday==0)
         real_gettimeofday = NULL;
         real_gettimeofday = dlsym(RTLD_NEXT, "gettimeofday");
-        
+
         /* check whether dlsym() worked */
         if (dlerror() == NULL) {
             has_real_gettimeofday = 1;
         }
     END_SINGLE_IF
     if (!has_real_gettimeofday) {  /* dlsym() failed */
-#ifdef DEBUG 
+#ifdef DEBUG
             (void) fprintf(stderr, "faketime problem: original gettimeofday() not found.\n");
-#endif 
+#endif
             return -1; /* propagate error to caller */
     }
-    
+
     /* initialize our result with the real current time */
     result = (*real_gettimeofday)(tv, NULL);
     if (result == -1) return result; /* original function failed */
     if (time_tptr != NULL)
-	*time_tptr = tv->tv_sec;
+        *time_tptr = tv->tv_sec;
     result = tv->tv_sec;
 #else
     /* Check whether we've got a pointer to the real time function yet */
@@ -446,10 +446,10 @@ static time_t _ftpl_time(time_t *time_tptr) {
         }
     END_SINGLE_IF
     if (!has_real_time) {  /* dlsym() failed */
-#ifdef DEBUG 
+#ifdef DEBUG
             (void) fprintf(stderr, "faketime problem: original time() not found.\n");
-#endif 
-	    if (time_tptr != NULL)
+#endif
+            if (time_tptr != NULL)
                 *time_tptr = -1;
             return -1; /* propagate error to caller */
     }
@@ -465,7 +465,7 @@ time_t time(time_t *time_tptr) {
     time_t result;
     time_t null_dummy;
     if (time_tptr == NULL) {
-	    time_tptr = &null_dummy;    
+        time_tptr = &null_dummy;
         /* (void) fprintf(stderr, "NULL pointer caught in time().\n"); */
     }
     result = _ftpl_time(time_tptr);
@@ -473,7 +473,7 @@ time_t time(time_t *time_tptr) {
 
     /* pass the real current time to our faking version, overwriting it */
     result = fake_time(time_tptr);
-    
+
     /* return the result to the caller */
     return result;
 }
@@ -486,32 +486,32 @@ int ftime(struct timeb *tp) {
 
     /* sanity check */
     if (tp == NULL)
-	return 0; 		/* ftime() always returns 0, see manpage */
-    
+        return 0;               /* ftime() always returns 0, see manpage */
+
     /* Check whether we've got a pointer to the real ftime() function yet */
     SINGLE_IF(has_real_ftime==0)
         real_ftime = NULL;
         real_ftime = dlsym(RTLD_NEXT, "ftime");
-        
+
         /* check whether dlsym() worked */
         if (dlerror() == NULL) {
             has_real_ftime = 1;
         }
     END_SINGLE_IF
     if (!has_real_ftime) {  /* dlsym() failed */
-#ifdef DEBUG 
+#ifdef DEBUG
             (void) fprintf(stderr, "faketime problem: original ftime() not found.\n");
-#endif 
+#endif
             tp = NULL;
             return 0; /* propagate error to caller */
     }
-    
+
     /* initialize our result with the real current time */
     result = (*real_ftime)(tp);
 
     /* pass the real current ftime to our faking version, overwriting it */
     result = fake_ftime(tp);
-    
+
     /* return the result to the caller */
     return result; /* will always be 0 (see manpage) */
 }
@@ -525,26 +525,26 @@ int gettimeofday(struct timeval *tv, void *tz) {
 
     /* sanity check */
     if (tv == NULL) {
-	    return -1;
+        return -1;
     }
 
     /* Check whether we've got a pointer to the real ftime() function yet */
     SINGLE_IF(has_real_gettimeofday==0)
         real_gettimeofday = NULL;
         real_gettimeofday = dlsym(RTLD_NEXT, "gettimeofday");
-        
+
         /* check whether dlsym() worked */
         if (dlerror() == NULL) {
             has_real_gettimeofday = 1;
         }
     END_SINGLE_IF
     if (!has_real_gettimeofday) {  /* dlsym() failed */
-#ifdef DEBUG 
+#ifdef DEBUG
             (void) fprintf(stderr, "faketime problem: original gettimeofday() not found.\n");
-#endif 
+#endif
             return -1; /* propagate error to caller */
     }
-    
+
     /* initialize our result with the real current time */
     result = (*real_gettimeofday)(tv, tz);
     if (result == -1) return result; /* original function failed */
@@ -553,7 +553,7 @@ int gettimeofday(struct timeval *tv, void *tz) {
     result = fake_gettimeofday(tv, tz);
 
     /* return the result to the caller */
-    return result; 
+    return result;
 }
 
 #ifdef POSIX_REALTIME
@@ -561,38 +561,38 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp) {
     static int (*real_clock_gettime)(clockid_t clk_id, struct timespec *tp);
     static int has_real_clock_gettime = 0;
     int result;
-    
+
     /* sanity check */
     if (tp == NULL) {
-	    return -1;
+        return -1;
     }
 
     /* Check whether we've got a pointer to the real clock_gettime() function yet */
     SINGLE_IF(has_real_clock_gettime==0)
         real_clock_gettime = NULL;
         real_clock_gettime = dlsym(RTLD_NEXT, "clock_gettime");
-        
+
         /* check whether dlsym() worked */
         if (dlerror() == NULL) {
             has_real_clock_gettime = 1;
         }
     END_SINGLE_IF
     if (!has_real_clock_gettime) {  /* dlsym() failed */
-#ifdef DEBUG 
+#ifdef DEBUG
             (void) fprintf(stderr, "faketime problem: original clock_gettime() not found.\n");
-#endif 
+#endif
             return -1; /* propagate error to caller */
     }
-    
+
     /* initialize our result with the real current time */
     result = (*real_clock_gettime)(clk_id, tp);
     if (result == -1) return result; /* original function failed */
 
     /* pass the real current time to our faking version, overwriting it */
     result = fake_clock_gettime(clk_id, tp);
-    
+
     /* return the result to the caller */
-    return result; 
+    return result;
 }
 #endif
 
@@ -620,15 +620,15 @@ time_t fake_time(time_t *time_tptr) {
     struct tm user_faked_time_tm;
     time_t user_faked_time_time_t;
     long user_offset;
-	double frac_user_offset;
+    double frac_user_offset;
     char filename[BUFSIZ], line[BUFFERLEN];
     FILE *faketimerc;
     static const char *user_faked_time_fmt = NULL;
 
     /* variables used for caching, introduced in version 0.6 */
-    static time_t last_data_fetch = 0;	/* not fetched previously at first call */
-    static int cache_expired = 1; 	/* considered expired at first call */
-    static int cache_duration = 10;	/* cache fake time input for 10 seconds */
+    static time_t last_data_fetch = 0;  /* not fetched previously at first call */
+    static int cache_expired = 1;       /* considered expired at first call */
+    static int cache_duration = 10;     /* cache fake time input for 10 seconds */
 
 #ifdef LIMITEDFAKING
     static long callcounter = 0;
@@ -663,8 +663,8 @@ static pthread_mutex_t time_mutex=PTHREAD_MUTEX_INITIALIZER;
     pthread_cleanup_push((void (*)(void *))pthread_mutex_unlock, (void *)&time_mutex);
 #endif
 
-	/* Sanity check by Karl Chan since v0.8 */
-	if (time_tptr == NULL) return -1;
+    /* Sanity check by Karl Chan since v0.8 */
+    if (time_tptr == NULL) return -1;
 
 #ifdef LIMITEDFAKING
     /* Check whether we actually should be faking the returned timestamp. */
@@ -733,17 +733,17 @@ static pthread_mutex_t time_mutex=PTHREAD_MUTEX_INITIALIZER;
 
         }
 
-    } 
+    }
 #endif
 
 
     if (last_data_fetch > 0) {
-    	if ((*time_tptr - last_data_fetch) > cache_duration) {
-	    	cache_expired = 1;
-	    }
+        if ((*time_tptr - last_data_fetch) > cache_duration) {
+            cache_expired = 1;
+        }
         else {
-		    cache_expired = 0;
-	    }
+            cache_expired = 0;
+        }
     }
 
 #ifdef NO_CACHING
@@ -752,47 +752,47 @@ static pthread_mutex_t time_mutex=PTHREAD_MUTEX_INITIALIZER;
 
     if (cache_expired == 1) {
 
-	last_data_fetch = *time_tptr;
+        last_data_fetch = *time_tptr;
 
-	/* Can be enabled for testing ...
-	fprintf(stderr, "***************++ Cache expired ++**************\n");
-	*/
+        /* Can be enabled for testing ...
+        fprintf(stderr, "***************++ Cache expired ++**************\n");
+        */
 
-	/* initialize with default */
-	snprintf(user_faked_time, BUFFERLEN, "+0"); 
-	
-	/* fake time supplied as environment variable? */
-	if (getenv("FAKETIME") != NULL) {
-		(void) strncpy(user_faked_time, getenv("FAKETIME"), BUFFERLEN-2);
-		user_faked_time[BUFFERLEN-1] = 0;	
-	}
-	else {	
-		/* check whether there's a .faketimerc in the user's home directory, or
-		* a system-wide /etc/faketimerc present.
-		* The /etc/faketimerc handling has been contributed by David Burley, 
-		* Jacob Moorman, and Wayne Davison of SourceForge, Inc. in version 0.6 */
-		(void) snprintf(filename, BUFSIZ, "%s/.faketimerc", getenv("HOME"));
-		if ((faketimerc = fopen(filename, "rt")) != NULL || 
-		(faketimerc = fopen("/etc/faketimerc", "rt")) != NULL) {
-		while(fgets(line, BUFFERLEN, faketimerc) != NULL) {
-			if ((strlen(line) > 1) && (line[0] != ' ') &&
-			(line[0] != '#') && (line[0] != ';')) {
-			while((line[strlen(line)-1] == 13) ||  
-				(line[strlen(line)-1] == 10))
-				line[strlen(line)-1] = 0;
-			strncpy(user_faked_time, line, BUFFERLEN-1);
-			user_faked_time[BUFFERLEN-1] = 0;
-			break;
-			}
-		}
-		fclose(faketimerc);
-		}		
-	} /* read fake time from file */
+        /* initialize with default */
+        snprintf(user_faked_time, BUFFERLEN, "+0");
+
+        /* fake time supplied as environment variable? */
+        if (getenv("FAKETIME") != NULL) {
+                (void) strncpy(user_faked_time, getenv("FAKETIME"), BUFFERLEN-2);
+                user_faked_time[BUFFERLEN-1] = 0;
+        }
+        else {
+                /* check whether there's a .faketimerc in the user's home directory, or
+                * a system-wide /etc/faketimerc present.
+                * The /etc/faketimerc handling has been contributed by David Burley,
+                * Jacob Moorman, and Wayne Davison of SourceForge, Inc. in version 0.6 */
+                (void) snprintf(filename, BUFSIZ, "%s/.faketimerc", getenv("HOME"));
+                if ((faketimerc = fopen(filename, "rt")) != NULL ||
+                (faketimerc = fopen("/etc/faketimerc", "rt")) != NULL) {
+                while(fgets(line, BUFFERLEN, faketimerc) != NULL) {
+                        if ((strlen(line) > 1) && (line[0] != ' ') &&
+                        (line[0] != '#') && (line[0] != ';')) {
+                        while((line[strlen(line)-1] == 13) ||
+                                (line[strlen(line)-1] == 10))
+                                line[strlen(line)-1] = 0;
+                        strncpy(user_faked_time, line, BUFFERLEN-1);
+                        user_faked_time[BUFFERLEN-1] = 0;
+                        break;
+                        }
+                }
+                fclose(faketimerc);
+                }
+        } /* read fake time from file */
 
 
-    	user_faked_time_fmt = getenv("FAKETIME_FMT");
-    	if (user_faked_time_fmt == NULL)
-        	user_faked_time_fmt = "%Y-%m-%d %T";
+        user_faked_time_fmt = getenv("FAKETIME_FMT");
+        if (user_faked_time_fmt == NULL)
+            user_faked_time_fmt = "%Y-%m-%d %T";
 
     } /* cache had expired */
 
@@ -801,7 +801,7 @@ static pthread_mutex_t time_mutex=PTHREAD_MUTEX_INITIALIZER;
  */
 //#ifdef __APPLE__
 //    SINGLE_IF(malloc_arena==0)
-//	malloc_arena = 1;
+//      malloc_arena = 1;
 //        return *time_tptr;
 //    END_SINGLE_IF
 //#endif
@@ -822,8 +822,8 @@ static pthread_mutex_t time_mutex=PTHREAD_MUTEX_INITIALIZER;
 
       case '+':
       case '-': /* User-specified offset */
-		/* fractional time offsets contributed by Karl Chen in v0.8 */
-		frac_user_offset = atof(user_faked_time);
+        /* fractional time offsets contributed by Karl Chen in v0.8 */
+        frac_user_offset = atof(user_faked_time);
 
         /* offset is in seconds by default, but the string may contain
          * multipliers...
@@ -833,8 +833,8 @@ static pthread_mutex_t time_mutex=PTHREAD_MUTEX_INITIALIZER;
         else if (strchr(user_faked_time, 'd') != NULL) frac_user_offset *= 60 * 60 * 24;
         else if (strchr(user_faked_time, 'y') != NULL) frac_user_offset *= 60 * 60 * 24 * 365;
 
-		/* Speed-up / slow-down contributed by Karl Chen in v0.8 */
-		if (strchr(user_faked_time, 'x') != NULL) {
+        /* Speed-up / slow-down contributed by Karl Chen in v0.8 */
+        if (strchr(user_faked_time, 'x') != NULL) {
             const double rate = atof(strchr(user_faked_time, 'x')+1);
             const long tdiff = (long long) *time_tptr - (long long)ftpl_starttime;
             const double timeadj = tdiff * (rate - 1.0);
@@ -852,15 +852,15 @@ static pthread_mutex_t time_mutex=PTHREAD_MUTEX_INITIALIZER;
 
         user_faked_time_time_t = mktime(&user_faked_time_tm);
         if (user_faked_time_time_t != -1) {
-			user_offset = - ( (long long int)ftpl_starttime - (long long int)user_faked_time_time_t );
-			
-			/* Speed-up / slow-down contributed by Karl Chen in v0.8 */
-			if (strchr(user_faked_time, 'x') != NULL) {
-				const double rate = atof(strchr(user_faked_time, 'x')+1);
-				const long tdiff = (long long) *time_tptr - (long long)ftpl_starttime;
-			    const double timeadj = tdiff * (rate - 1.0);
-		        *time_tptr += (long) timeadj;
-	        }
+            user_offset = - ( (long long int)ftpl_starttime - (long long int)user_faked_time_time_t );
+
+            /* Speed-up / slow-down contributed by Karl Chen in v0.8 */
+            if (strchr(user_faked_time, 'x') != NULL) {
+                const double rate = atof(strchr(user_faked_time, 'x')+1);
+                const long tdiff = (long long) *time_tptr - (long long)ftpl_starttime;
+                const double timeadj = tdiff * (rate - 1.0);
+                *time_tptr += (long) timeadj;
+            }
 
             *time_tptr += user_offset;
         }
@@ -879,7 +879,7 @@ int fake_ftime(struct timeb *tp) {
     time_t temp_tt = tp->time;
 
     tp->time = fake_time(&temp_tt);
-    
+
     return 0; /* always returns 0, see manpage */
 }
 
@@ -916,19 +916,18 @@ int __gettimeofday(struct timeval *tv, void *tz) {
 
 #ifdef POSIX_REALTIME
 int __clock_gettime(clockid_t clk_id, struct timespec *tp) {
-	return clock_gettime(clk_id, tp);
+    return clock_gettime(clk_id, tp);
 }
 #endif
 
 int __ftime(struct timeb *tp) {
-	return ftime(tp);
+    return ftime(tp);
 }
 
 time_t __time(time_t *time_tptr) {
-	return time(time_tptr);
+    return time(time_tptr);
 }
 #endif
 #endif
 
 /* eof */
-

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,10 +22,10 @@ test: timetest functest
 functest:
 	./testframe.sh functests
 
-clean: 
+clean:
 	@rm -f ${OBJ} timetest
 
 distclean: clean
-	@echo 
+	@echo
 
 .PHONY: all test clean distclean

--- a/test/Makefile.MacOS
+++ b/test/Makefile.MacOS
@@ -1,7 +1,7 @@
 CC = gcc
 
 CFLAGS = -std=gnu99 -Wall -DFAKE_STAT
-LDFLAGS = 
+LDFLAGS =
 
 SRC = timetest.c
 OBJ = ${SRC:.c=.o}
@@ -22,10 +22,10 @@ test: timetest functest
 functest:
 	./testframe.sh functests
 
-clean: 
+clean:
 	@rm -f ${OBJ} timetest
 
 distclean: clean
-	@echo 
+	@echo
 
 .PHONY: all test clean distclean

--- a/test/README-testframe.txt
+++ b/test/README-testframe.txt
@@ -24,7 +24,7 @@
 # testsuite script can make use of any functions defined
 # in these inc files.  the environment variable
 # TESTSUITE_NAME is set to the filename of the testsuite
-# script, for possible use in warning or info messages.  
+# script, for possible use in warning or info messages.
 #
 # see functests/test_true.sh for a simple example of
 # a test suite script.

--- a/test/functests/dont_test_false.sh
+++ b/test/functests/dont_test_false.sh
@@ -4,4 +4,3 @@ run()
 {
 	run_testcase false
 }
-

--- a/test/functests/test_true.sh
+++ b/test/functests/test_true.sh
@@ -5,4 +5,3 @@ run()
 	run_testcase true
 	return 0
 }
-

--- a/test/timetest.c
+++ b/test/timetest.c
@@ -3,13 +3,13 @@
  *
  *  This file is part of the FakeTime Preload Library.
  *
- *  The FakeTime Preload Library is free software; you can redistribute it 
- *  and/or modify it under the terms of the GNU General Public License as 
- *  published by the Free Software Foundation; either version 2 of the 
+ *  The FakeTime Preload Library is free software; you can redistribute it
+ *  and/or modify it under the terms of the GNU General Public License as
+ *  published by the Free Software Foundation; either version 2 of the
  *  License, or (at your option) any later version.
  *
- *  The FakeTime Preload Library is distributed in the hope that it will 
- *  be useful, but WITHOUT ANY WARRANTY; without even the implied warranty 
+ *  The FakeTime Preload Library is distributed in the hope that it will
+ *  be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
  *  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU General Public License for more details.
  *


### PR DESCRIPTION
Used (emacs) M-x untabify for whole faketime.c as the prevailing
style in that file used spaces for indentation.

Used M-x delete-trailing-whitespace to all files that had either
trailing whitespace or empty lines at the end of file to remove
those.
