### PR TITLE
Implementation of implicit '-f'

### DIFF
--- a/src/faketime
+++ b/src/faketime
@@ -37,6 +37,14 @@ if [ "$offset" = "-m" ] ; then USEMT=1; shift; offset="$1"; fi
 if [ "$offset" = "-f" ] ; then USEDIRECT=1; shift; offset="$1"; fi
 if [ "$offset" = "-m" ] ; then USEMT=1; shift; offset="$1"; fi
 
+# Have USEDIRECT implicitly set when $offset begins with + or -, followed
+# by number and not having 3 consecutive alphabet characters.
+# This matches e.g. '-16hx2' but not '-3 weeks'.
+case $offset in
+	[+-][0-9]*[A-Za-z][A-Za-z][A-Za-z]*) ;;
+	[+-][0-9]*) USEDIRECT=1 ;;
+esac
+
 if [ -z "$offset" -o "$offset" = "-h" -o "$offset" = "-?" -o "$offset" = "--help" ] ; then
 	echo ""
 	echo "Usage: $0 [switches] timestamp program arguments"


### PR DESCRIPTION
When $offset arg looks like the relative value described in README
section "4d) Using offsets for relative dates", set USEDIRECT variable
even when '-f' option is not present. Without the '-f' the $offset would
be useless so this is convenience feature for the user. Using '-f' in
command line to explicitly set USEDIRECT is retained.
