### PR TITLE
use mmap for checking rcfile

### DIFF
--- a/src/faketime.c
+++ b/src/faketime.c
@@ -805,16 +805,16 @@ static pthread_mutex_t time_mutex=PTHREAD_MUTEX_INITIALIZER;
 #endif
 
 #ifdef DYNAMIC_FAKETIMERC
-    if (etc_rcfile_map) {
-        if (strcmp(prev_etc_rcfile, etc_rcfile_map) != 0) {
-            cache_expired = 1;
-            strcpy(prev_etc_rcfile, etc_rcfile_map);
-        }
-    }
     if (home_rcfile_map) {
         if (strcmp(prev_home_rcfile, home_rcfile_map) != 0) {
             cache_expired = 1;
             strcpy(prev_home_rcfile, home_rcfile_map);
+        }
+    }
+    if (cache_expired != 1 && etc_rcfile_map) {
+        if (strcmp(prev_etc_rcfile, etc_rcfile_map) != 0) {
+            cache_expired = 1;
+            strcpy(prev_etc_rcfile, etc_rcfile_map);
         }
     }
 #endif


### PR DESCRIPTION
In response to #12:
- Cleaned up the changes and treat the `mmap()` checks only as a signal to activate the original cache update code.
- Only use when `DYNAMC_FAKETIMERC` flag is set. If you think this is not necessary, even better =)
- For perf reasons, it only checks `/etc/faketimerc` and not user `.faketimerc`s. Hopefully having `FAKETIMERC` in the compile flag name helps a bit with this clarification?
- I would much prefer this get merged rather than #13 cause this requries far fewer external changes
