### PR TITLE
Fix rouding issues

### DIFF
--- a/TODO
+++ b/TODO
@@ -6,4 +6,3 @@ Open issues / next steps for libfaketime development
   and available through the wrapper shell script
 - fake timer_create and friends
 - handle CLOCK_REALTIME_COARSE and CLOCK_MONOTONIC_COARSE
-- fake time(), etc. using clock_gettime() to provide more continuous faking with x10

--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -130,11 +130,11 @@ static int (*real_ppoll)(struct pollfd *, nfds_t,
                const struct timespec *, const sigset_t *);
 #ifdef __APPLE__
 static int (*real_clock_get_time)(clock_serv_t clock_serv, mach_timespec_t *cur_timeclockid_t);
+static int apple_clock_gettime(clockid_t clk_id, struct timespec *tp);
 static clock_serv_t clock_serv_real;
 #endif
 /* prototypes */
 time_t fake_time(time_t *time_tptr);
-int    fake_ftime(struct timeb *tp);
 int    fake_gettimeofday(struct timeval *tv, void *tz);
 int    fake_clock_gettime(clockid_t clk_id, struct timespec *tp);
 
@@ -808,29 +808,34 @@ int poll(struct pollfd *fds, nfds_t nfds, int timeout)
   return ret;
 }
 
+/**
+ * time() implementation using clock_gettime()
+ * @note Does not check for EFAULT, see man 2 time
+ */
 time_t time(time_t *time_tptr) {
-    time_t result;
-    time_t null_dummy;
-    if (time_tptr == NULL) {
-        time_tptr = &null_dummy;
-        /* (void) fprintf(stderr, "NULL pointer caught in time().\n"); */
-    }
-    DONT_FAKE_TIME(result = (*real_time)(time_tptr));
-    if (result == ((time_t) -1)) return result;
+  struct timespec tp;
+  time_t result;
 
-    /* pass the real current time to our faking version, overwriting it */
-    result = fake_time(time_tptr);
+  DONT_FAKE_TIME(result = (*real_clock_gettime)(CLOCK_REALTIME, &tp));
+  if (result == -1) return -1;
 
-    /* return the result to the caller */
-    return result;
+  /* pass the real current time to our faking version, overwriting it */
+  (void)fake_clock_gettime(CLOCK_REALTIME, &tp);
+
+  if (time_tptr != NULL) {
+    *time_tptr = tp.tv_sec;
+  }
+  return tp.tv_sec;
+
 }
 
 
-int ftime(struct timeb *tp) {
-    int result;
+int ftime(struct timeb *tb) {
+  struct timespec tp;
+   int result;
 
     /* sanity check */
-    if (tp == NULL)
+    if (tb == NULL)
         return 0;               /* ftime() always returns 0, see manpage */
 
     /* Check whether we've got a pointer to the real ftime() function yet */
@@ -838,15 +843,23 @@ int ftime(struct timeb *tp) {
 #ifdef DEBUG
             (void) fprintf(stderr, "faketime problem: original ftime() not found.\n");
 #endif
-            tp = NULL;
             return 0; /* propagate error to caller */
     }
 
-    /* initialize our result with the real current time */
-    DONT_FAKE_TIME(result = (*real_ftime)(tp));
+    /* initialize our TZ result with the real current time */
+    DONT_FAKE_TIME(result = (*real_ftime)(tb));
+    if (result == -1) {
+      return result;
+    }
 
-    /* pass the real current ftime to our faking version, overwriting it */
-    result = fake_ftime(tp);
+    DONT_FAKE_TIME(result = (*real_clock_gettime)(CLOCK_REALTIME, &tp));
+    if (result == -1) return -1;
+
+    /* pass the real current time to our faking version, overwriting it */
+    (void)fake_clock_gettime(CLOCK_REALTIME, &tp);
+
+    tb->time = tp.tv_sec;
+    tb->millitm = tp.tv_nsec / 1000000;
 
     /* return the result to the caller */
     return result; /* will always be 0 (see manpage) */
@@ -983,7 +996,6 @@ void __attribute__ ((constructor)) ftpl_init(void)
     real_time = dlsym(RTLD_NEXT, "time");
     real_ftime = dlsym(RTLD_NEXT, "ftime");
     real_gettimeofday = dlsym(RTLD_NEXT, "gettimeofday");
-    real_clock_gettime = dlsym(RTLD_NEXT, "clock_gettime");
     real_nanosleep = dlsym(RTLD_NEXT, "nanosleep");
     real_usleep = dlsym(RTLD_NEXT, "usleep");
     real_sleep = dlsym(RTLD_NEXT, "sleep");
@@ -992,6 +1004,9 @@ void __attribute__ ((constructor)) ftpl_init(void)
     real_ppoll = dlsym(RTLD_NEXT, "ppoll");
 #ifdef __APPLE__
     real_clock_get_time = dlsym(RTLD_NEXT, "clock_get_time");
+    real_clock_gettime = apple_clock_gettime;
+#else
+    real_clock_gettime = dlsym(RTLD_NEXT, "clock_gettime");
 #endif
 
     ft_shm_init();
@@ -1308,19 +1323,6 @@ time_t fake_time(time_t *time_tptr) {
   return *time_tptr;
 }
 
-int fake_ftime(struct timeb *tp) {
-  struct timespec ts;
-  int ret;
-  ts.tv_sec = tp->time;
-  ts.tv_nsec =tp->millitm * 1000000 + ftpl_starttime.real.tv_nsec % 1000000;
-
-  ret = fake_clock_gettime(CLOCK_REALTIME, &ts);
-  tp->time = ts.tv_sec;
-  tp->millitm =ts.tv_nsec / 1000000;
-
-  return ret;
-}
-
 int fake_gettimeofday(struct timeval *tv, void *tz) {
   struct timespec ts;
   int ret;
@@ -1335,11 +1337,15 @@ int fake_gettimeofday(struct timeval *tv, void *tz) {
 }
 
 #ifdef __APPLE__
-
-int clock_get_time(clock_serv_t clock_serv, mach_timespec_t *cur_timeclockid_t)
-{
+/**
+ * clock_gettime implementation for __APPLE__
+ * @note It always behave like being called with CLOCK_REALTIME.
+ */
+static int apple_clock_gettime(clockid_t clk_id, struct timespec *tp) {
   int result;
-  struct timespec ts;
+  mach_timespec_t cur_timeclockid_t;
+  (void) clk_id; /* unused */
+
   if (NULL == real_clock_get_time) {  /* dlsym() failed */
 #ifdef DEBUG
     (void) fprintf(stderr, "faketime problem: original clock_get_time() not found.\n");
@@ -1347,17 +1353,25 @@ int clock_get_time(clock_serv_t clock_serv, mach_timespec_t *cur_timeclockid_t)
     return -1; /* propagate error to caller */
   }
 
+  DONT_FAKE_TIME(result = (*real_clock_get_time)(clock_serv_real, &cur_timeclockid_t));
+  tp->tv_sec =  cur_timeclockid_t.tv_sec;
+  tp->tv_nsec = cur_timeclockid_t.tv_nsec;
+  return result;
+}
+
+int clock_get_time(clock_serv_t clock_serv, mach_timespec_t *cur_timeclockid_t)
+{
+  int result;
+  struct timespec ts;
   /*
    * Initialize our result with the real current time from CALENDAR_CLOCK.
    * This is a bit of cheating, but we don't keep track of obtained clock
    * services.
    */
-  DONT_FAKE_TIME(result = (*real_clock_get_time)(clock_serv_real, cur_timeclockid_t));
+  DONT_FAKE_TIME(result = (*real_clock_gettime)(CLOCK_REALTIME, &ts));
   if (result == -1) return result; /* original function failed */
 
   /* pass the real current time to our faking version, overwriting it */
-  ts.tv_sec = cur_timeclockid_t->tv_sec;
-  ts.tv_sec = cur_timeclockid_t->tv_nsec;
   result = fake_clock_gettime(CLOCK_REALTIME, &ts);
   cur_timeclockid_t->tv_sec = ts.tv_sec;
   cur_timeclockid_t->tv_nsec = ts.tv_nsec;


### PR DESCRIPTION
With f44eda6258bc20eae4c1e92e5f35b7ec654d54ad examples finally show the proper output:
 ./faketime -f '+2,5y x10,0' /bin/bash -c 'date; while true; do echo $SECONDS ; sleep 1 ; done'
Fri Sep  4 21:49:30 CEST 2015
0
1
2
3
...
instead of
./faketime -f '+2,5y x10,0' /bin/bash -c 'date; while true; do echo $SECONDS ; sleep 1 ; done'
Fri Sep  4 21:51:39 CEST 2015
0
0
0
0
10
10
10
10
10
10
10
10
10
10
20
20
20
...
