### PR TITLE
Add --exclude-monotonic command line option.

### DIFF
--- a/src/faketime.c
+++ b/src/faketime.c
@@ -72,8 +72,9 @@ void usage(const char *name)
   printf("for advanced options, such as stopping the wall clock and make it run faster or slower.\n");
   printf("\n");
   printf("The optional switches are:\n");
-  printf("  -m        : Use the multi-threaded version of libfaketime\n");
-  printf("  -f        : Use the advanced timestamp specification format (see manpage)\n");
+  printf("  -m                  : Use the multi-threaded version of libfaketime\n");
+  printf("  -f                  : Use the advanced timestamp specification format (see manpage)\n");
+  printf("  --exclude-monotonic : Prevent monotonic clock from drifting (not the raw monotonic one)\n");
   printf("\n");
   printf("Examples:\n");
   printf("%s 'last friday 5 pm' /bin/date\n", name);
@@ -119,6 +120,12 @@ int main (int argc, char **argv)
     else if (0 == strcmp(argv[curr_opt], "-f"))
     {
       use_direct = true;
+      curr_opt++;
+      continue;
+    }
+    else if (0 == strcmp(argv[curr_opt], "--exclude-monotonic"))
+    {
+      setenv("DONT_FAKE_MONOTONIC", "1", true);
       curr_opt++;
       continue;
     }

--- a/test/functests/test_exclude_mono.sh
+++ b/test/functests/test_exclude_mono.sh
@@ -1,0 +1,87 @@
+# Checks that setting DONT_FAKE_MONOTONIC actually prevent
+# libfaketime from faking monotonic clocks.
+#
+# We do this by freezing time at a specific and arbitrary date with faketime,
+# and making sure that if we set DONT_FAKE_MONOTONIC to 1, calling
+# clock_gettime(CLOCK_MONOTONIC) returns two different values.
+#
+# We also make sure that if we don't set DONT_FAKE_MONOTONIC to 1, in other
+# words when we use the default behavior, two subsequent calls to
+# clock_gettime(CLOCK_MONOTONIC) do return different values.
+
+init()
+{
+    typeset testsuite="$1"
+    PLATFORM=$(platform)
+    if [ -z "$PLATFORM" ]; then
+        echo "$testsuite: unknown platform! quitting"
+        return 1
+    fi
+    echo "# PLATFORM=$PLATFORM"
+    return 0
+}
+
+run()
+{
+    init
+
+    run_testcase dont_fake_mono
+    run_testcase fake_mono
+}
+
+get_token()
+{
+    string=$1
+    token_index=$2
+    separator=$3
+
+    echo $string | cut -d "$separator" -f $token_index
+}
+
+assert_timestamps_neq()
+{
+    timestamps=$1
+    msg=$2
+
+    first_timestamp=$(get_token "${timestamps}" 1 ' ')
+    second_timestamp=$(get_token "${timestamps}" 2 ' ')
+
+    assertneq "${first_timestamp}" "${second_timestamp}" "${msg}"
+}
+
+assert_timestamps_eq()
+{
+    timestamps=$1
+    msg=$2
+
+    first_timestamp=$(get_token "${timestamps}" 1 ' ')
+    second_timestamp=$(get_token "${timestamps}" 2 ' ')
+
+    asserteq "${first_timestamp}" "${second_timestamp}" "${msg}"
+}
+
+get_monotonic_time()
+{
+    dont_fake_mono=$1; shift;
+    clock_id=$1; shift;
+    DONT_FAKE_MONOTONIC=${dont_fake_mono} fakecmd "2014-07-21 09:00:00" \
+    /bin/bash -c "for i in 1 2; do \
+    perl -w -MTime::HiRes=clock_gettime,${clock_id} -E \
+    'say clock_gettime(${clock_id})'; \
+    sleep 1; \
+    done"
+}
+
+dont_fake_mono()
+{
+    timestamps=$(get_monotonic_time 1 CLOCK_MONOTONIC)
+    msg="When not faking monotonic time, timestamps should be different"
+    assert_timestamps_neq "${timestamps}" "${msg}"
+}
+
+fake_mono()
+{
+    timestamps=$(get_monotonic_time 0 CLOCK_MONOTONIC)
+    msg="When faking monotonic, timestamps should be equal"
+    assert_timestamps_eq "${timestamps}" "${msg}"
+}


### PR DESCRIPTION
This PR adds the --exclude-monotonic command line flag to faketime. 
It prevents faketime from overriding the clock with id CLOCK_MONOTONIC when using clock_gettime.

It also adds support to libfaketime for an env variable named DONT_FAKE_MONOTONIC that
has the same effect.

Functional tests for DONT_FAKE_MONOTONIC support are included.

This change came out of the need to test that high-level (JavaScript API) timers in Node.js are actually implemented using monotonic time and not wall-clock time. To test this, we use faketime (with this change) to freeze wall-clock time, but not monotonic time. If our timers are implemented correctly, when the low-level timers (always implemented using monotonic time) fire, if our high-level timers have already fired, it means that they're correctly implemented too.

I think other developers could benefit from this PR if they want to test their timers-related code too.

I made this PR against master and not develop because I hadn't read README.developers until now. I noticed that the develop branch hasn't seen any commit for a while, so just in case README.developers is out of date and developers now submit PRs on master, I'm sending it to be merged on master. If you want it made against develop, just let me know and I'll create another one.

Finally, this PR is just to get the ball rolling and to open a discussion. If we can agree on this initial concept, it would be nice to add other things. For instance, I'd like to be able to prevent faketime to override any type of clock (monotonic, monotonic_raw and realtime), and to have a command line API that is easier to use (like --exclude-clock=comma_separated_list_of_clock_ids ). Depending on the outcome of this discussion, I will implement that too.

I welcome your comments and suggestions!

Thank you,
