### PR TITLE
Make libfaketime build, run and pass tests on SmartOS.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -66,10 +66,20 @@ INSTALL ?= install
 
 PREFIX ?= /usr/local
 LIBDIRNAME ?= /lib/faketime
+PLATFORM ?=$(shell uname)
 
 CFLAGS += -std=gnu99 -Wall -Wextra -Werror -DFAKE_STAT -DFAKE_SLEEP -DFAKE_TIMERS -DFAKE_INTERNAL_CALLS -fPIC -DPREFIX='"'$(PREFIX)'"' -DLIBDIRNAME='"'$(LIBDIRNAME)'"'
+ifeq ($(PLATFORM),SunOS)
+CFLAGS += -D__EXTENSIONS__ -D_XOPEN_SOURCE=600
+endif
+
 LIB_LDFLAGS += -shared
-LDFLAGS += -Wl,--version-script=libfaketime.map -lpthread
+
+LDFLAGS += -lpthread
+ifneq ($(PLATFORM),SunOS)
+LDFLAGS += -Wl,--version-script=libfaketime.map
+endif
+
 LDADD += -ldl -lm -lrt
 BIN_LDFLAGS += -lrt
 

--- a/src/faketime.c
+++ b/src/faketime.c
@@ -208,8 +208,15 @@ int main (int argc, char **argv)
     struct ft_shared_s *ft_shared;
     char shared_objs[PATH_BUFSIZE];
 
-    snprintf(sem_name, PATH_BUFSIZE -1 ,"/faketime_sem_%d", getpid());
-    snprintf(shm_name, PATH_BUFSIZE -1 ,"/faketime_shm_%d", getpid());
+    /*
+     * Casting of getpid() return value to long needed to make GCC on SmartOS
+     * happy, since getpid's return value's type on SmartOS is long. Since
+     * getpid's return value's type is int on most other systems, and that
+     * sizeof(long) always >= sizeof(int), this works on all platforms without
+     * the need for crazy #ifdefs.
+     */
+    snprintf(sem_name, PATH_BUFSIZE -1 ,"/faketime_sem_%ld", (long)getpid());
+    snprintf(shm_name, PATH_BUFSIZE -1 ,"/faketime_shm_%ld", (long)getpid());
 
     if (SEM_FAILED == (sem = sem_open(sem_name, O_CREAT|O_EXCL, S_IWUSR|S_IRUSR, 1)))
     {
@@ -351,6 +358,8 @@ int main (int argc, char **argv)
     }
     exit(WEXITSTATUS(ret));
   }
+
+  return EXIT_SUCCESS;
 }
 
 /*

--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -22,7 +22,6 @@
  */
 
 #define _GNU_SOURCE             /* required to get RTLD_NEXT defined */
-#define _XOPEN_SOURCE           /* required to get strptime() defined */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -57,7 +56,11 @@
 
 #ifndef __APPLE__
 extern char *__progname;
+#ifdef __sun
+#include "sunos_endian.h"
+#else
 #include <endian.h>
+#endif
 #else
 /* endianness related macros */
 #define htobe64(x) OSSwapHostToBigInt64(x)
@@ -1437,6 +1440,10 @@ void __attribute__ ((constructor)) ftpl_init(void)
     real_clock_gettime  =   dlsym(RTLD_NEXT, "clock_gettime");
   }
 #ifdef FAKE_TIMERS
+#if defined(__sun)
+    real_timer_gettime_233 =  dlsym(RTLD_NEXT, "timer_gettime");
+    real_timer_settime_233 =  dlsym(RTLD_NEXT, "timer_settime");
+#else
   real_timer_settime_22 =   dlvsym(RTLD_NEXT, "timer_settime","GLIBC_2.2");
   real_timer_settime_233 =  dlvsym(RTLD_NEXT, "timer_settime","GLIBC_2.3.3");
   if (NULL == real_timer_settime_233)
@@ -1449,6 +1456,7 @@ void __attribute__ ((constructor)) ftpl_init(void)
   {
     real_timer_gettime_233 =  dlsym(RTLD_NEXT, "timer_gettime");
   }
+#endif
 #endif
 #endif
 

--- a/src/sunos_endian.h
+++ b/src/sunos_endian.h
@@ -1,0 +1,12 @@
+
+#ifndef SUN_OS_ENDIAN_H
+#define SUN_OS_ENDIAN_H
+
+#include <sys/byteorder.h>
+
+#define htobe64(x) BE_64(x)
+#define be64toh(x) BE_64(x)
+#define htole64(x) LE_64(x)
+#define le64toh(x) LE_64(x)
+
+#endif /* SUN_OS_ENDIAN_H */

--- a/test/functests/common.inc
+++ b/test/functests/common.inc
@@ -9,6 +9,7 @@ platform()
 	*Darwin*) echo "mac" ;;
 	*Linux*) echo "linuxlike" ;;
     GNU|GNU/kFreeBSD) echo "linuxlike" ;;
+        *SunOS*) echo "sunos" ;;
 	*) echo 1>&2 unsupported platform, uname=\"$out\" ;;
 	esac
 }
@@ -23,6 +24,15 @@ mac_fakecmd()
 	export DYLD_FORCE_FLAT_NAMESPACE=1
 	FAKETIME="$timestring" \
 	"$@"
+}
+
+sunos_fakecmd()
+{
+        typeset timestring="$1"; shift
+        typeset fakelib=../src/libfaketime.so.1
+        export LD_PRELOAD=$fakelib
+        FAKETIME="$timestring" \
+        "$@"
 }
 
 # run faked command on linuxlike OS


### PR DESCRIPTION
Since SmartOS is close to SunOS, it's possible that these changes make
libfaketime build and run on other SunOS-like platforms.

These changes were also tested on MacOS X and Ubuntu 12.04, and no regression
appeared during testing.
