### PR TITLE
Wait for all transitive child processes to exit

### DIFF
--- a/src/faketime.c
+++ b/src/faketime.c
@@ -198,6 +198,8 @@ int main (int argc, char **argv)
     /* simply pass format string along */
     setenv("FAKETIME", argv[curr_opt], true);
   }
+  int keepalive_fds[2];
+  (void) (pipe(keepalive_fds) + 1);
 
   /* we just consumed the timestamp option */
   curr_opt++;
@@ -334,6 +336,7 @@ int main (int argc, char **argv)
   /* run command and clean up shared objects */
   if (0 == (child_pid = fork()))
   {
+    close(keepalive_fds[0]); /* only parent needs to read this */
     if (EXIT_SUCCESS != execvp(argv[curr_opt], &argv[curr_opt]))
     {
       perror("Running specified command failed");
@@ -343,7 +346,10 @@ int main (int argc, char **argv)
   else
   {
     int ret;
+    char buf;
+    close(keepalive_fds[1]); /* only children need keep this open */
     waitpid(child_pid, &ret, 0);
+    (void) (read(keepalive_fds[0], &buf, 1) + 1); /* reads 0B when all children exit */
     cleanup_shobjs();
     if (WIFSIGNALED(ret))
     {


### PR DESCRIPTION
This fixes #56 by blocking faketime's exit on a read from a pipe whose write end is inherited by all child processes. In the process, I also fixed the fact that the pipe being used to calculate time in the absence of the -f option was being leaked into child processes' fd tables.
