### PR TITLE
New features: custom timestamp file and cache managment

### DIFF
--- a/README
+++ b/README
@@ -315,12 +315,14 @@ Using relative offsets or 'start at' dates solves this problem.
 libfaketime then will always report the faked time based on the real
 current time and the offset you've specified.
 
-Please also note that your specification of the fake time is cached for 10
-seconds in order to enhance the library's performance. Thus, if you change the
+Please also note that your default specification of the fake time is cached for
+10 seconds in order to enhance the library's performance. Thus, if you change the
 content of $HOME/.faketimerc or /etc/faketimerc while a program is running, it
 may take up to 10 seconds before the new fake time is applied. If this is a
-problem in your scenario, you can disable caching at compile time by adding the
-command line option -DNO_CACHING to this library's Makefile.
+problem in your scenario, you can change number of seconds before the file is read
+again with environment variable FAKETIME_CACHE_DURATION, or disable caching at all
+with FAKETIME_NO_CACHE=1. Remember that disabling the cache may negatively
+influence the performance.
 
 
 4f) Faking the date and time system-wide

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,12 +30,6 @@
 #	  FAKE_TIMERS
 #	      - Also intercept timer_settime() and timer_gettime()
 #
-#     NO_CACHING
-#         - Disables the caching of the fake time offset. Only disable caching
-#           if you change the fake time offset during program runtime very
-#           frequently. Disabling the cache may negatively influence the
-#           performance.
-#
 #	  MULTI_ARCH
 #	  	  - If MULTI_ARCH is set, the faketime wrapper program will put a literal
 #	  	    $LIB into the LD_PRELOAD environment variable it creates, which makes

--- a/src/Makefile.OSX
+++ b/src/Makefile.OSX
@@ -21,12 +21,6 @@
 # 	  FAKE_SLEEP
 # 	      - Also intercept sleep(), nanosleep(), usleep(), alarm(), [p]poll()
 #
-#     NO_CACHING
-#         - Disables the caching of the fake time offset. Only disable caching
-#           if you change the fake time offset during program runtime very
-#           frequently. Disabling the cache may negatively influence the
-#           performance.
-#
 #   * Compilation addition: second libMT target added for building the pthread-
 #     enabled library as a separate library
 #


### PR DESCRIPTION
For my case I need a file with fake timestamp per process. I cannot use environment variable to change time offset, because of use python subprocess to run my application with faketime (no external changes to the enviroment are possible). Using single file would limit application testing to a single thread per user/machine. That's why I added custom timestamp file. 
Changes to these files might also be quite often, and that might be per test case option to turn caching off. So as not to keep two different libraries I decided to introduce another variable. Additional feature is possibility to set custom value for cache duration.
