### PR TITLE
Fix libfaketimeMT build to define PTHREAD

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -76,7 +76,7 @@ LIBS = libfaketime.so.${SONAME} libfaketimeMT.so.${SONAME}
 
 all: ${LIBS} ${BINS}
 
-faketimeMT.o: EXTRA_FLAGS := -DPTHREAD -DPTHREAD_SINGLETHREADED_TIME
+libfaketimeMT.o: EXTRA_FLAGS := -DPTHREAD -DPTHREAD_SINGLETHREADED_TIME
 
 ${LIBS_OBJ}: libfaketime.c
 	${CC} -o $@ -c ${CFLAGS} ${EXTRA_FLAGS} $<


### PR DESCRIPTION
Currently libfaketimeMT.o is compiled without `--DPTHREAD -DPTHREAD_SINGLETHREADED_TIME` .

The patch fixes the `Makefile` to refer to the correct object file name.

With the fix indeed the MT file is built with those directives defined (third `cc` invocation in the output):

```
$ make
cc -o libfaketime.o -c -std=gnu99 -Wall -Wextra -Werror -DFAKE_STAT -DFAKE_SLEEP -DFAKE_TIMERS -DFAKE_INTERNAL_CALLS -fPIC -DPREFIX='"'/usr/local'"' -DLIBDIRNAME='"'/lib/faketime'"'  libfaketime.c
cc -o libfaketime.so.1 -Wl,-soname,libfaketime.so.1 -Wl,--version-script=libfaketime.map -lpthread -shared libfaketime.o -ldl -lm -lrt
cc -o libfaketimeMT.o -c -std=gnu99 -Wall -Wextra -Werror -DFAKE_STAT -DFAKE_SLEEP -DFAKE_TIMERS -DFAKE_INTERNAL_CALLS -fPIC -DPREFIX='"'/usr/local'"' -DLIBDIRNAME='"'/lib/faketime'"' -DPTHREAD -DPTHREAD_SINGLETHREADED_TIME libfaketime.c
cc -o libfaketimeMT.so.1 -Wl,-soname,libfaketimeMT.so.1 -Wl,--version-script=libfaketime.map -lpthread -shared libfaketimeMT.o -ldl -lm -lrt
cc -o faketime -std=gnu99 -Wall -Wextra -Werror -DFAKE_STAT -DFAKE_SLEEP -DFAKE_TIMERS -DFAKE_INTERNAL_CALLS -fPIC -DPREFIX='"'/usr/local'"' -DLIBDIRNAME='"'/lib/faketime'"'  faketime.c -Wl,--version-script=libfaketime.map -lpthread -lrt
```