### PR TITLE
Mention possibility of running java in README

### DIFF
--- a/README
+++ b/README
@@ -70,8 +70,9 @@ documentation whether it can be achieved by using libfaketime directly.
   intercept by removing the -DPTHREAD_SINGLETHREADED_TIME from the Makefile and
   rebuilding libfaketimeMT.so.1
 
-* Java-/JVM-based applications and others with a complex run-time environment
-  are known to not, or not reliably, work with libfaketime.
+* Java-/JVM-based applications work but you need to pass in an extra argument
+  (DONT_FAKE_MONOTONIC).  See usage basics below for details.  Without this 
+  argument the java command usually hangs.
 
 * libfaketime will eventually be bypassed by applications that dynamically load
   system libraries, such as librt, explicitly themselves instead of relying on
@@ -138,6 +139,12 @@ Tue Nov 23 12:01:05 CEST 2016
 
 user@host> LD_PRELOAD=/usr/local/lib/libfaketime.so.1 FAKETIME="-15d" date
 Mon Nov  8 12:01:12 CEST 2016
+
+user@host> LD_PRELOAD=/usr/local/lib/libfaketime.so.1 FAKETIME="-15d" 
+DONT_FAKE_MONOTONIC=1 java -version
+java version "1.8.0_111"
+Java(TM) SE Runtime Environment (build 1.8.0_111-b14)
+Java HotSpot(TM) 64-Bit Server VM (build 25.111-b14, mixed mode)
 
 The basic way of running any command/program with libfaketime enabled is to
 make sure the environment variable LD_PRELOAD contains the path and


### PR DESCRIPTION
Hi,

Wanted to let you know I've been able to use this library successfully with java applications when setting the DONT_FAKE_MONOTONIC argument.  Without it, the java app hangs.

What do you think?