### PR TITLE
Add FAKETIME_WAIT_MS to force pthread_cond_timedwait to wait x ms instead of what its parameters say.

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -2519,6 +2519,8 @@ int pthread_cond_timedwait_common(pthread_cond_t *cond, pthread_mutex_t *mutex, 
   struct timespec tp, tdiff_actual, realtime, faketime;
   struct timespec *tf = NULL;
   struct pthread_cond_monotonic* e;
+  char *tmp_env;
+  int wait_ms;
   clockid_t clk_id;
   int result;
 
@@ -2538,14 +2540,32 @@ int pthread_cond_timedwait_common(pthread_cond_t *cond, pthread_mutex_t *mutex, 
     faketime = realtime;
     (void)fake_clock_gettime(clk_id, &faketime);
 
-    timespecsub(abstime, &faketime, &tp);
-    if (user_rate_set)
+    if ((tmp_env = getenv("FAKETIME_WAIT_MS")) != NULL)
     {
-      timespecmul(&tp, 1.0 / user_rate, &tdiff_actual);
+      wait_ms = atol(tmp_env);
+      DONT_FAKE_TIME(result = (*real_clock_gettime)(clk_id, &realtime));
+      if (result == -1)
+      {
+        return EINVAL;
+      }
+
+      tdiff_actual.tv_sec = wait_ms / 1000;
+      tdiff_actual.tv_nsec = (wait_ms % 1000) * 1000000;
+      timespecadd(&realtime, &tdiff_actual, &tp);
+
+      tf = &tp;
     }
     else
     {
-      tdiff_actual = tp;
+      timespecsub(abstime, &faketime, &tp);
+      if (user_rate_set)
+      {
+        timespecmul(&tp, 1.0 / user_rate, &tdiff_actual);
+      }
+      else
+      {
+        tdiff_actual = tp;
+      }
     }
 
     /* For CLOCK_MONOTONIC, pthread_cond_timedwait uses clock_gettime


### PR DESCRIPTION
The problem is that if we `pthread_cond_timedwait`, then change the timestamp file, the process will get stuck because it has no way to notice that the time has changed and we have no way to prod it awake from the outside.

(The proper solution would be running a watcher thread for the file from libfaketime, but that's a lot of effort.)

This did not used to be a problem because pthread_cond_timedwait would effectively busyloop (since it'd pass a time far in the past.) Since this function was fixed, this problem has been exposed.

The pull request adds a workaround FAKETIME_WAIT_MS variable that forces `pthread_cond_timedwait` to instead wait that many milliseconds, implementing a busyloop. Since `pthread_cond_timedwait` is permitted to wake up whenever and for whatever reason, this is still correct.