### PR TITLE
fix gettimeofday() on alpha (see https://bugs.debian.org/890813)

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -1675,7 +1675,11 @@ static void ftpl_init(void)
   real_lstat64 =            dlsym(RTLD_NEXT, "__lxstat64");
   real_time =               dlsym(RTLD_NEXT, "time");
   real_ftime =              dlsym(RTLD_NEXT, "ftime");
+#if defined(__alpha__) && defined(__GLIBC__)
+  real_gettimeofday =       dlvsym(RTLD_NEXT, "gettimeofday", "GLIBC_2.1");
+#else
   real_gettimeofday =       dlsym(RTLD_NEXT, "gettimeofday");
+#endif
 #ifdef FAKE_SLEEP
   real_nanosleep =          dlsym(RTLD_NEXT, "nanosleep");
   real_usleep =             dlsym(RTLD_NEXT, "usleep");
@@ -1688,7 +1692,11 @@ static void ftpl_init(void)
 #endif
 #ifdef FAKE_INTERNAL_CALLS
   real___ftime =              dlsym(RTLD_NEXT, "__ftime");
+#  if defined(__alpha__) && defined(__GLIBC__)
+  real___gettimeofday =       dlvsym(RTLD_NEXT, "__gettimeofday", "GLIBC_2.1");
+#  else
   real___gettimeofday =       dlsym(RTLD_NEXT, "__gettimeofday");
+#  endif
   real___clock_gettime  =     dlsym(RTLD_NEXT, "__clock_gettime");
 #endif
 #ifdef FAKE_PTHREAD


### PR DESCRIPTION
In https://bugs.debian.org/890813, Michael Cree <mcree@orcon.net.nz>
reports:

>  The faketime package fails to work correctly on the Alpha
>  architecture. This failure of faketime to work correctly is the
>  reason for the mbedtls FTBFS, which uses faketime in its test
>  suite [1].
>
>  Consider the following test program (which I call "time-test"):
>
>  #include <stdio.h>
>  #include <sys/time.h>
>  #include <unistd.h>
>
>  int main(void)
>  {
>      struct timeval tv;
>
>      for (int j=0; j<5; j++) {
>          usleep(10000);
>          gettimeofday(&tv, NULL);
>          printf("s=%ld    us=%ld\n", tv.tv_sec, tv.tv_usec);
>      }
>      return 0;
>  }
>
>  When run it produces output like:
>
>  s=1519025990    us=838219
>  s=1519025990    us=848965
>  s=1519025990    us=859711
>  s=1519025990    us=870456
>  s=1519025990    us=881202
>
>  But when run as (with faketime built in its source directory):
>
>  LD_PRELOAD=faketime-0.9.7/src/libfaketime.so.1 FAKETIME="-1d" ./time-test
>
>  the output is:
>
>  s=2199023743604    us=0
>  s=2199023657204    us=0
>  s=2199023570804    us=0
>  s=2199023484404    us=0
>  s=2199023398004    us=0
>
>  which is definitely not correct.
>
>  The reason for the incorrect behaviour is that there are two
>  gettimeofday symbols in libc on Alpha and the dlsym() call to link
>  to the gettimeofday() is picking up the function with the wrong ABI.
>  I attach a patch to fix that.  Faketime built with the attached
>  patch works correctly and with a fixed faketime the mbedtls source
>  package builds to completion on Alpha.