### PR TITLE
Use CPPFLAGS during compilation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -89,13 +89,13 @@ all: ${LIBS} ${BINS}
 libfaketimeMT.o: EXTRA_FLAGS := -DPTHREAD_SINGLETHREADED_TIME
 
 ${LIBS_OBJ}: libfaketime.c
-	${CC} -o $@ -c ${CFLAGS} ${EXTRA_FLAGS} $<
+	${CC} -o $@ -c ${CFLAGS} ${CPPFLAGS} ${EXTRA_FLAGS} $<
 
 %.so.${SONAME}: %.o libfaketime.map
 	${CC} -o $@ -Wl,-soname,$@ ${LDFLAGS} ${LIB_LDFLAGS} $< ${LDADD}
 
 ${BINS}: faketime.c
-	${CC} -o $@ ${CFLAGS} ${EXTRA_FLAGS} $< ${LDFLAGS} ${BIN_LDFLAGS}
+	${CC} -o $@ ${CFLAGS} ${CPPFLAGS} ${EXTRA_FLAGS} $< ${LDFLAGS} ${BIN_LDFLAGS}
 
 clean:
 	@rm -f ${LIBS_OBJ} ${LIBS} ${BINS}


### PR DESCRIPTION
CPPFLAGS is traditionally used to include C preprocessor flags.  While
faketime doesn't apply anything to CPPFLAGS directly, it is good form
to adopt standard settings that might be externally applied.