### PR TITLE
Rename DONT_FAKE_MONOTONIC to FAKETIME_DONT_FAKE_MONOTONIC for consistency

### DIFF
--- a/README
+++ b/README
@@ -71,8 +71,8 @@ documentation whether it can be achieved by using libfaketime directly.
   rebuilding libfaketimeMT.so.1
 
 * Java-/JVM-based applications work but you need to pass in an extra argument
-  (DONT_FAKE_MONOTONIC).  See usage basics below for details.  Without this
-  argument the java command usually hangs.
+  (FAKETIME_DONT_FAKE_MONOTONIC).  See usage basics below for details.  Without
+  this argument the java command usually hangs.
 
 * libfaketime will eventually be bypassed by applications that dynamically load
   system libraries, such as librt, explicitly themselves instead of relying on
@@ -141,7 +141,7 @@ user@host> LD_PRELOAD=/usr/local/lib/libfaketime.so.1 FAKETIME="-15d" date
 Mon Nov  8 12:01:12 CEST 2016
 
 user@host> LD_PRELOAD=/usr/local/lib/libfaketime.so.1 FAKETIME="-15d"
-DONT_FAKE_MONOTONIC=1 java -version
+FAKETIME_DONT_FAKE_MONOTONIC=1 java -version
 java version "1.8.0_111"
 Java(TM) SE Runtime Environment (build 1.8.0_111-b14)
 Java HotSpot(TM) 64-Bit Server VM (build 25.111-b14, mixed mode)

--- a/src/faketime.c
+++ b/src/faketime.c
@@ -124,7 +124,7 @@ int main (int argc, char **argv)
     }
     else if (0 == strcmp(argv[curr_opt], "--exclude-monotonic"))
     {
-      setenv("DONT_FAKE_MONOTONIC", "1", true);
+      setenv("FAKETIME_DONT_FAKE_MONOTONIC", "1", true);
       curr_opt++;
       continue;
     }

--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -1802,7 +1802,8 @@ static void ftpl_init(void)
       cache_enabled = 0;
     }
   }
-  if ((tmp_env = getenv("DONT_FAKE_MONOTONIC")) != NULL)
+  if ((tmp_env = getenv("FAKETIME_DONT_FAKE_MONOTONIC")) != NULL
+    || (tmp_env = getenv("DONT_FAKE_MONOTONIC")) != NULL)
   {
     if (0 == strcmp(tmp_env, "1"))
     {

--- a/test/functests/test_exclude_mono.sh
+++ b/test/functests/test_exclude_mono.sh
@@ -1,12 +1,12 @@
-# Checks that setting DONT_FAKE_MONOTONIC actually prevent
+# Checks that setting FAKETIME_DONT_FAKE_MONOTONIC actually prevent
 # libfaketime from faking monotonic clocks.
 #
 # We do this by freezing time at a specific and arbitrary date with faketime,
-# and making sure that if we set DONT_FAKE_MONOTONIC to 1, calling
+# and making sure that if we set FAKETIME_DONT_FAKE_MONOTONIC to 1, calling
 # clock_gettime(CLOCK_MONOTONIC) returns two different values.
 #
-# We also make sure that if we don't set DONT_FAKE_MONOTONIC to 1, in other
-# words when we use the default behavior, two subsequent calls to
+# We also make sure that if we don't set FAKETIME_DONT_FAKE_MONOTONIC to 1,
+# in other words when we use the default behavior, two subsequent calls to
 # clock_gettime(CLOCK_MONOTONIC) do return different values.
 
 init()
@@ -64,7 +64,8 @@ get_monotonic_time()
 {
     dont_fake_mono=$1; shift;
     clock_id=$1; shift;
-    DONT_FAKE_MONOTONIC=${dont_fake_mono} fakecmd "2014-07-21 09:00:00" \
+    FAKETIME_DONT_FAKE_MONOTONIC=${dont_fake_mono} \
+    fakecmd "2014-07-21 09:00:00" \
     /bin/bash -c "for i in 1 2; do \
     perl -w -MTime::HiRes=clock_gettime,${clock_id} -E \
     'say clock_gettime(${clock_id})'; \


### PR DESCRIPTION
All other environment variables used by libfaketime start with `FAKETIME_`, why not this one?

The old variable still works, but is no longer mentioned in the README.