### PR TITLE
Unused variable compiler error

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,14 @@
+Since 0.9.8:
+    - Compile-time CFLAG FAKE_SETTIME can be enabled to
+      intercept calls to clock_settime(), settimeofday(), and
+      adjtime(). (suggested and prototyped by @ojura)
+    - Additional compile-time CFLAGs can be passed via the
+      environment variable FAKETIME_COMPILE_CFLAGS when
+      running 'make'.
+    - src/Makefile CFLAG FORCE_PTHREAD_NONVER should be set on
+      systems that hang on CLOCK_REALTIME, or that hang on
+      CLOCK_MONOTONIC where FORCE_MONOTONIC_FIX is not sufficient.
+
 Since 0.9.7:
     - Passthrough for unknown clock ids to avoid error messages
     - Fixes for multithreaded operations (mliertzer, qnox)

--- a/README
+++ b/README
@@ -456,6 +456,16 @@ a lot of processes are started (e.g., servers handling many containers
 or similar virtualization mechanisms).
 
 
+Intercepting time-setting calls
+-------------------------------
+
+libfaketime can be compiled with the CFLAG "-DFAKE_SETTIME" in order
+to also intercept time-setting functions, i.e., clock_settime(),
+settimeofday(), and adjtime(). Instead of passing the timestamp a
+program sets through to the system, only the FAKETIME environment
+variable will be adjusted accordingly.
+
+
 4f) Faking the date and time system-wide
 ----------------------------------------
 

--- a/README
+++ b/README
@@ -97,6 +97,12 @@ documentation whether it can be achieved by using libfaketime directly.
   src/Makefile and recompile libfaketime. Do not set FORCE_MONOTONIC_FIX on
   platforms where the test does not hang.
 
+  If you observe hangs on the CLOCK_REALTIME test, add the CFLAG
+  -DFORCE_PTHREAD_NONVER. Also set this FORCE_PTHREAD_NONVER flag in case
+  FORCE_MONOTONIC_FIX alone does not solve the hang on the MONOTONIC_CLOCK
+  test.
+
+
 3. Installation
 ---------------
 

--- a/README.packagers
+++ b/README.packagers
@@ -1,0 +1,62 @@
+README for packagers of libfaketime
+
+First, thank you for your efforts to make libfaketime packages available
+on your platform / distribution!
+
+libfaketime has tagged releases about once every 1-2 years, made available
+through github.com/wolfcw/libfaketime, but usually it is also safe (i.e.,
+stable) to use the latest HEAD of the master branch, which contains bug
+fixes since the last tagged release.
+
+You may want to familiarize yourself with the options you can set into
+src/Makefile, but sane defaults for stable operations have been chosen.
+
+Currently, libfaketime does not use autotools yet, so there is
+_no_ ./configure step, but "make" and "make test" will work as expected.
+
+
+However, one problem makes it somewhat difficult to get libfaketime
+working on different platforms:
+
+libfaketime currently has the challenge that depending on the version
+of glibc and the platform (e.g., x86_64 or aarch64) certain compiler
+CFLAGS have to be set manually, as we have not yet found a way to
+safely determine behavior at run-time automatically.
+
+Please proceed as follows:
+
+- run "make test". If everything runs through smoothly and you do not
+  encounter any hangs or test failure reports, use the binaries as
+  they are.
+
+- If you encounter endless hangs during the CLOCK_REALTIME test,
+  add -DFORCE_PTHREAD_NONVER to the CFLAGS.
+
+- If you encounter endless hangs during the CLOCK_MONOTONIC test,
+  add -DFORCE_MONOTONIC_FIX to the CFLAGS. If it works with that,
+  it's fine, otherwise additionally use -DFORCE_PTHREAD_NONVER.
+
+CFLAGS can also be passed through the FAKETIME_COMPILE_CFLAGS environment
+variable, so for example
+
+  FAKETIME_COMPILE_CFLAGS="-DFORCE_PTHREAD_NONVER" make test
+
+would create the libfaketime binaries and run the tests with the
+FORCE_PTHREAD_NONVER flag set in a single step.
+
+Please do not use FORCE_MONOTONIC_FIX by default, as it would result
+in incorrect operations on platforms that do not need it.
+
+Our observations with a limited number of Linux distributions is that
+libfaketime may require different compile flags per platform even
+if the same distribution and glibc version is used across these
+platforms.
+
+As soon as we have found a reliable way to automatically choose the
+correct compile-time flags, we will remove this burden from you as
+packager for obvious reasons. Until then, please feel free to report
+your experiences with different platforms and distribution versions
+through the issue tracker on Github.
+
+Again, thanks for your time and effort to make libfaketime available
+easily for everyone else!

--- a/src/Makefile
+++ b/src/Makefile
@@ -30,6 +30,9 @@
 #     FAKE_PTHREAD
 #         - Intercept pthread_cond_timedwait
 #
+#     FAKE_SETTIME
+#         - Intercept clock_settime(), settimeofday(), and adjtime()
+#
 #     FORCE_MONOTONIC_FIX
 #         - If the test program hangs forever on
 #                  " pthread_cond_timedwait: CLOCK_MONOTONIC test

--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -286,8 +286,6 @@ static double user_rate = 1.0;
 static bool user_rate_set = false;
 static struct timespec user_per_tick_inc = {0, -1};
 static bool user_per_tick_inc_set = false;
-static bool user_per_tick_inc_set_backup = false;
-
 enum ft_mode_t {FT_FREEZE, FT_START_AT, FT_NOOP} ft_mode = FT_FREEZE;
 
 /* Time to fake is not provided through FAKETIME env. var. */
@@ -681,6 +679,7 @@ static bool load_time(struct timespec *tp)
 #include <sys/stat.h>
 
 static int fake_stat_disabled = 0;
+static bool user_per_tick_inc_set_backup = false;
 
 void lock_for_stat()
 {

--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -3157,7 +3157,7 @@ int pthread_cond_timedwait_232(pthread_cond_t *cond, pthread_mutex_t *mutex, con
 }
 
 __asm__(".symver pthread_cond_timedwait_225, pthread_cond_timedwait@GLIBC_2.2.5");
-#ifdef __ARM_ARCH
+#if defined __ARM_ARCH || defined FORCE_PTHREAD_NONVER
 __asm__(".symver pthread_cond_timedwait_232, pthread_cond_timedwait@@");
 __asm__(".symver pthread_cond_init_232, pthread_cond_init@@");
 __asm__(".symver pthread_cond_destroy_232, pthread_cond_destroy@@");


### PR DESCRIPTION
Building without FAKE_STAT defined causes compilation errors due to
unused variable user_per_tick_inc_set_backup.  Move declaration inside
FAKE_STAT section along with the code making use of it