### PR TITLE
timespec multiplication overflow fix

### DIFF
--- a/src/time_ops.h
+++ b/src/time_ops.h
@@ -60,9 +60,9 @@
 #define timermul2(tvp, c, result, prefix)                           \
   do                                                                \
   {                                                                 \
-    long long tmp_time;                                             \
-    tmp_time = (c) * ((tvp)->tv_sec * SEC_TO_##prefix##SEC +        \
-               (tvp)->tv_##prefix##sec);                            \
+    int64_t tmp_time;                                             \
+    tmp_time = (c) * (int64_t) ((tvp)->tv_sec * SEC_TO_##prefix##SEC +        \
+               (int64_t) (tvp)->tv_##prefix##sec);                            \
     (result)->tv_##prefix##sec = tmp_time % SEC_TO_##prefix##SEC;   \
     (result)->tv_sec = (tmp_time - (result)->tv_##prefix##sec) /    \
       SEC_TO_##prefix##SEC;                                         \


### PR DESCRIPTION
In 32 bit platforms, overflow occurs during timespec multiplication in macro function `timespecmul2()`.
In this function, `long` value which represent time in seconds is multiplied with large number `1E9` to convert it to nano seconds, this value is not able to fit in 4 byte memory.
Size of `long` type in 32 bit platform is 4 bytes. This is not problem in 64 bit platforms as the size of `long` type in 64 bit platform is 8 bytes. 
For quick verification: https://godbolt.org/z/WTwfWj

Fix suggested is to use `int64_t` for the multiplication result.
