### PR TITLE
fake_clock_gettime: avoid placing large buffers on the stack

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -2770,8 +2770,8 @@ int fake_clock_gettime(clockid_t clk_id, struct timespec *tp)
     /* fake time supplied as environment variable? */
     if (parse_config_file)
     {
-      char custom_filename[BUFSIZ];
-      char filename[BUFSIZ];
+      static char custom_filename[BUFSIZ];
+      static char filename[BUFSIZ];
       FILE *faketimerc;
       /* check whether there's a .faketimerc in the user's home directory, or
        * a system-wide /etc/faketimerc present.
@@ -2783,7 +2783,7 @@ int fake_clock_gettime(clockid_t clk_id, struct timespec *tp)
           (faketimerc = fopen(filename, "rt")) != NULL ||
           (faketimerc = fopen("/etc/faketimerc", "rt")) != NULL)
       {
-        char line[BUFFERLEN];
+        static char line[BUFFERLEN];
         while(fgets(line, BUFFERLEN, faketimerc) != NULL)
         {
           if ((strlen(line) > 1) && (line[0] != ' ') &&


### PR DESCRIPTION
The real `clock_gettime` doesn't use much stackspace. Allocating large stack buffers may cause breakage when `fake_clock_gettime` is called in threads that have been started with a small amount of stackspace. (This problem was found when using faketime with D's background GC threads, which set the stacksize to 16KB.)