### PR TITLE
Fix timing issue with multiple threads

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -2637,7 +2637,7 @@ static void pthread_cleanup_mutex_lock(void *data)
 {
   struct LockedState *state = data;
   pthread_mutex_unlock(&state->mutex);
-  sigprocmask(SIG_SETMASK, &state->original_mask, NULL);
+  pthread_sigmask(SIG_SETMASK, &state->original_mask, NULL);
 }
 #endif
 
@@ -2672,8 +2672,7 @@ int fake_clock_gettime(clockid_t clk_id, struct timespec *tp)
   // block all signals while locked. prevents deadlocks if signal interrupts in in mid-operation.
   sigset_t all_signals;
   sigfillset(&all_signals);
-  sigprocmask(SIG_SETMASK, &all_signals, &state.original_mask);
-
+  pthread_sigmask(SIG_SETMASK, &all_signals, &state.original_mask);
   pthread_mutex_lock(&state.mutex);
   pthread_cleanup_push(pthread_cleanup_mutex_lock, &state);
 #endif


### PR DESCRIPTION
Three problems were found and fixed:

- `sigprocmask` is the wrong function; technically, only `pthread_sigmask` is allowed in multithreaded programs. (They're aliases, but it's the principle of the thing.)
- In some cases, due to early return from `fake_clock_gettime`, the faketime lock was not released. Return is now handled by a goto. (I'm sorry, this was the only way I could think of.)
- I fucked up: my previous pull request was assigning to the global lock state struct before we actually had the lock. This is naturally a bad idea, and was causing hangs in practice as we restored the wrong process mask. Also fixed. Mea culpa.