### PR TITLE
Fix make test build failure on gcc 9.3

### DIFF
--- a/test/timetest.c
+++ b/test/timetest.c
@@ -216,7 +216,10 @@ printf("%s", 0 == 1 ? argv[0] : "");
     printf("time()         : Current date and time: %s", ctime(&now));
     printf("time(NULL)     : Seconds since Epoch  : %u\n", (unsigned int)time(NULL));
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     ftime(&tb);
+#pragma GCC diagnostic pop
     printf("ftime()        : Current date and time: %s", ctime(&tb.time));
 
     printf("(Intentionally sleeping 2 seconds...)\n");


### PR DESCRIPTION
On Ubuntu 20.04 using gcc 9.3, make test fails due to a deprecated
function (ftime) warning in combination with -Werror in timetest.c.
Since the warning is from a test testing that the deprecated function
can be replaced using LD_PRELOAD, I think it's reasonable to just
silence the warning in that case.

```
gcc -c -std=gnu99 -Wall -DFAKE_STAT -Werror -Wextra  timetest.c
timetest.c: In function ‘main’:
timetest.c:219:5: error: ‘ftime’ is deprecated [-Werror=deprecated-declarations]
  219 |     ftime(&tb);
      |     ^~~~~
In file included from timetest.c:26:
/usr/include/x86_64-linux-gnu/sys/timeb.h:39:12: note: declared here
   39 | extern int ftime (struct timeb *__timebuf)
      |            ^~~~~
cc1: all warnings being treated as errors
make[1]: *** [Makefile:12: timetest.o] Error 1
```

```
$ cc --version
cc (Ubuntu 9.3.0-10ubuntu2) 9.3.0
```

The warning could be enabled everywhere in the Makefile, but maybe in time other functions will get deprecated and maybe those will be ones that should be fixed instead of ignored.