### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,19 @@ language: c
 matrix:
   include:
     - os: linux
+      arch: amd64
+      compiler: gcc
+    - os: linux
+      arch: ppc64le
       compiler: gcc
     - os: osx
       osx_image: xcode11
 
 script:
   - cd ${TRAVIS_BUILD_DIR}
-  - FAKETIME_COMPILE_CFLAGS="-DFORCE_MONOTONIC_FIX" make
+  - if [ "$TRAVIS_ARCH" = ppc64le ]; then
+       FAKETIME_COMPILE_CFLAGS="-DFORCE_MONOTONIC_FIX -DFORCE_PTHREAD_NONVER" make;
+    else
+       FAKETIME_COMPILE_CFLAGS="-DFORCE_MONOTONIC_FIX" make; 
+    fi
   - make test


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/libfaketime/builds/188534440 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!