### PR TITLE
Try to fix warning about clobbering under optimization (Closes #284)

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -2840,7 +2840,7 @@ int fake_clock_gettime(clockid_t clk_id, struct timespec *tp)
   }
 
   // {ret = value; goto abort;} to call matching pthread_cleanup_pop and return value
-  int ret = INT_MAX;
+  volatile int ret = INT_MAX;
 
 #ifdef PTHREAD_SINGLETHREADED_TIME
   static pthread_mutex_t time_mutex = PTHREAD_MUTEX_INITIALIZER;


### PR DESCRIPTION
Without this fix, when compiling with `-O1` or more, we see:

```
libfaketime.c: In function ‘fake_clock_gettime’:
libfaketime.c:2843:7: error: variable ‘ret’ might be clobbered by ‘longjmp’ or ‘vfork’ [-Werror=clobbered]
 2843 |   int ret = INT_MAX;
      |       ^~~
cc1: all warnings being treated as errors
```

This error doesn't happen when using `-O0`.

The warning appears to happen when the compiler optimizes `ret`
because it is the return value for the function call (meaning maybe
preserved in a register, or some other more risky placement that might
break during the `goto` error cases?).  Explicitly marking it as
volatile should keep the compiler from optimizing that way, regardless
of the level of optimization the user asks for.

I got the idea to use `volatile` here from the rather confused
discussion in
https://cboard.cprogramming.com/c-programming/147829-help-me-warning-argument-fmtstring-might-clobbered-longjmp-vfork.html

I admit I don't fully understand what's going on here, and would be
grateful for review by someone who understands the machinery here at a
deeper level than I do.