### PR TITLE
Ease build of getrandom_test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.o
 *.so.1
 timetest
+test/getrandom_test
 
 src/libfaketime.dylib.1
 src/libfaketime.1.dylib

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,8 +22,14 @@ test: timetest functest
 functest:
 	./testframe.sh functests
 
+getrandom_test: getrandom_test.c
+	${CC} -o $@ ${CFLAGS} $<
+
+randomtest: getrandom_test
+	./randomtest.sh
+
 clean:
-	@rm -f ${OBJ} timetest
+	@rm -f ${OBJ} timetest getrandom_test
 
 distclean: clean
 	@echo

--- a/test/getrandom_test.c
+++ b/test/getrandom_test.c
@@ -2,13 +2,13 @@
 #include <sys/random.h>
 #include <stdlib.h>
 
-int main(int argc, char **argv) {
+int main() {
   char *buf = calloc(100, 1);
   size_t buflen = 100;
   unsigned flags = GRND_NONBLOCK;
 
   fprintf(stdout, "Before getrandom:\n");
-  for (int i=0; i < buflen; i++) { fprintf(stdout, "%hhu ", buf[i]); }
+  for (size_t i=0; i < buflen; i++) { fprintf(stdout, "%hhu ", buf[i]); }
   fprintf(stdout, "\n");
 
   int result = getrandom(buf, buflen, flags);
@@ -17,7 +17,7 @@ int main(int argc, char **argv) {
 
 
   fprintf(stdout, "After getrandom:\n");
-  for (int i=0; i < buflen; i++) { fprintf(stdout, "%hhu ", buf[i]); }
+  for (size_t i=0; i < buflen; i++) { fprintf(stdout, "%hhu ", buf[i]); }
   fprintf(stdout, "\n");
 
   free(buf);

--- a/test/randomtest.sh
+++ b/test/randomtest.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+error=0
+./getrandom_test > run0
+FAKERANDOM_SEED=0x12345678DEADBEEF LD_PRELOAD=../src/libfaketime.so.1 ./getrandom_test > run1
+FAKERANDOM_SEED=0x12345678DEADBEEF LD_PRELOAD=../src/libfaketime.so.1 ./getrandom_test > run2
+FAKERANDOM_SEED=0x0000000000000000 LD_PRELOAD=../src/libfaketime.so.1 ./getrandom_test > run3
+
+
+if diff -u run0 run1 > /dev/null; then
+    error=1
+    printf >&2 'test run without a seed produced the same data as a run with a seed!\n'
+fi
+if ! diff -u run1 run2; then
+    error=2
+    printf >&2 'test runs with identical seeds differed!\n'
+fi
+if diff -u run2 run3 >/dev/null; then
+    error=3
+    printf >&2 'test runs with different seeds produced the same data!\n'
+fi
+
+rm -f run0 run1 run2 run3
+
+if [ 0 = $error ]; then
+    printf 'getrandom interception test successful.\n'
+fi
+
+exit $error


### PR DESCRIPTION
In trying to test the experimental getrandom features, I found a few
minor problems.  These changes should make it easier to test.

After building, the developer can now just do:

    make -C test randomtest

This will do a basic verfication that the feature works as expected.

I haven't tried to integrate this with the overall "make test".  To do
that right, it should condition the test on the definition of
FAKE_RANDOM.