### PR TITLE
Improve tests for FAKE_RANDOM

### DIFF
--- a/test/getrandom_test.c
+++ b/test/getrandom_test.c
@@ -2,7 +2,7 @@
 #include <sys/random.h>
 #include <stdlib.h>
 
-int main() {
+int base() {
   char *buf = calloc(100, 1);
   size_t buflen = 100;
   unsigned flags = GRND_NONBLOCK;
@@ -22,4 +22,8 @@ int main() {
 
   free(buf);
   return 0;
+}
+
+int main() {
+  return base() + base();
 }

--- a/test/randomtest.sh
+++ b/test/randomtest.sh
@@ -2,27 +2,35 @@
 
 FTPL="${FAKETIME_TESTLIB:-../src/libfaketime.so.1}"
 
+set -e
+
 error=0
-./getrandom_test > run0
+./getrandom_test > run-base
+LD_PRELOAD="$FTPL" ./getrandom_test > run0
 FAKERANDOM_SEED=0x12345678DEADBEEF LD_PRELOAD="$FTPL" ./getrandom_test > run1
 FAKERANDOM_SEED=0x12345678DEADBEEF LD_PRELOAD="$FTPL" ./getrandom_test > run2
 FAKERANDOM_SEED=0x0000000000000000 LD_PRELOAD="$FTPL" ./getrandom_test > run3
 
 
-if diff -u run0 run1 > /dev/null; then
+if diff -u run-base run0 > /dev/null; then
     error=1
+    printf >&2 'test run without the LD_PRELOAD matches a run without LD_PRELOAD'
+fi
+
+if diff -u run0 run1 > /dev/null; then
+    error=2
     printf >&2 'test run without a seed produced the same data as a run with a seed!\n'
 fi
 if ! diff -u run1 run2; then
-    error=2
+    error=3
     printf >&2 'test runs with identical seeds differed!\n'
 fi
 if diff -u run2 run3 >/dev/null; then
-    error=3
+    error=4
     printf >&2 'test runs with different seeds produced the same data!\n'
 fi
 
-rm -f run0 run1 run2 run3
+rm -f run-base run0 run1 run2 run3
 
 if [ 0 = $error ]; then
     printf 'getrandom interception test successful.\n'


### PR DESCRIPTION
Previously, we had failed to test code with getrandom() against
LD_PRELOAD when FAKERANDOM_SEED was unset.

We also want to try calling getrandom twice in a single process to
make sure that works OK.