### PR TITLE
test getrandom() in library initialization without FAKERANDOM_SEED

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.so.1
 timetest
 test/getrandom_test
+test/librandom.o
+test/librandom.so
+test/use_lib_random
 
 src/libfaketime.dylib.1
 src/libfaketime.1.dylib

--- a/test/Makefile
+++ b/test/Makefile
@@ -25,13 +25,22 @@ functest:
 getrandom_test: getrandom_test.c
 	${CC} -o $@ ${CFLAGS} $<
 
-randomtest: getrandom_test
+randomtest: getrandom_test use_lib_random
 	./randomtest.sh
 
+librandom.o: librandom.c
+	${CC} -c -o $@ -fpic ${CFLAGS} $<
+
+librandom.so: librandom.o
+	${CC} -o $@ -shared ${CFLAGS} $<
+
+use_lib_random: use_lib_random.c librandom.so
+	${CC} -L. -o $@ ${CFLAGS}  $< -lrandom
+
 clean:
-	@rm -f ${OBJ} timetest getrandom_test
+	@rm -f ${OBJ} timetest getrandom_test librandom.o librandom.so use_lib_random
 
 distclean: clean
 	@echo
 
-.PHONY: all test clean distclean
+.PHONY: all test clean distclean randomtest

--- a/test/librandom.c
+++ b/test/librandom.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+#include <sys/random.h>
+
+void func() {
+  fprintf(stderr, "  called func()\n");
+}
+
+
+static __attribute__((constructor)) void rnd_init() {
+  unsigned int targ;
+  ssize_t ret = getrandom(&targ, sizeof(targ), 0);
+  if (ret == sizeof(targ)) {
+    fprintf(stderr, "  getrandom() yielded 0x%08x\n", targ);
+  } else {
+    fprintf(stderr, "  getrandom() failed with only %zd\n", ret);
+  }
+}

--- a/test/librandom.h
+++ b/test/librandom.h
@@ -1,0 +1,6 @@
+#ifndef __LIBRANDOM_H__
+#define __LIBRANDOM_H__
+
+extern void func();
+
+#endif

--- a/test/randomtest.sh
+++ b/test/randomtest.sh
@@ -32,6 +32,14 @@ fi
 
 rm -f run-base run0 run1 run2 run3
 
+printf 'testing shared object with getrandom() in library constructor\n'
+LD_LIBRARY_PATH=. ./use_lib_random
+printf 'now with LD_PRELOAD and FAKERANDOM_SEED\n'
+FAKERANDOM_SEED=0x0000000000000000 LD_PRELOAD="$FTPL" LD_LIBRARY_PATH=. ./use_lib_random
+# this demonstrates the crasher from https://github.com/wolfcw/libfaketime/issues/295
+printf 'now with LD_PRELOAD without FAKERANDOM_SEED\n'
+LD_PRELOAD="$FTPL" LD_LIBRARY_PATH=. ./use_lib_random
+
 if [ 0 = $error ]; then
     printf 'getrandom interception test successful.\n'
 fi

--- a/test/use_lib_random.c
+++ b/test/use_lib_random.c
@@ -1,0 +1,6 @@
+#include "librandom.h"
+
+int main() {
+  func();
+  return 0;
+}


### PR DESCRIPTION
Running "make randomtest" should demonstrates the segfault described
in https://github.com/wolfcw/libfaketime/issues/295

It currently fails for me:

``` console
$ make randomtest
gcc -c -o librandom.o -fpic -std=gnu99 -Wall -DFAKE_STAT -Werror -Wextra  librandom.c
gcc -o librandom.so -shared -std=gnu99 -Wall -DFAKE_STAT -Werror -Wextra  librandom.o
gcc -L. -o use_lib_random -std=gnu99 -Wall -DFAKE_STAT -Werror -Wextra   use_lib_random.c -lrandom
./randomtest.sh
testing shared object with getrandom() in library constructor
  getrandom() yielded 0xe5587d15
  called func()
now with LD_PRELOAD and FAKERANDOM_SEED
  getrandom() yielded 0x00000000
  called func()
now with LD_PRELOAD without FAKERANDOM_SEED
Segmentation fault
make: *** [Makefile:29: randomtest] Error 139
$
```