### PR TITLE
Enable intercepting getpid()

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -41,6 +41,9 @@
 #     FAKE_RANDOM
 #         - Intercept getrandom()
 #
+#     FAKE_PID
+#         - Intercept getpid()
+#
 #     FORCE_MONOTONIC_FIX
 #         - If the test program hangs forever on
 #                  " pthread_cond_timedwait: CLOCK_MONOTONIC test

--- a/test/pidtest.sh
+++ b/test/pidtest.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+FTPL="${FAKETIME_TESTLIB:-../src/libfaketime.so.1}"
+
+set -e
+run1=$(LD_PRELOAD="$FTPL" sh -c 'echo $$')
+run2=$(LD_PRELOAD="$FTPL" sh -c 'echo $$')
+
+if [ $run1 = $run2 ]; then
+   printf >&2 'got the same pid twice in a row without setting FAKETIME_FAKEPID\n'
+   exit 1
+fi
+
+output=$(FAKETIME_FAKEPID=13 LD_PRELOAD="$FTPL" sh -c 'echo $$')
+
+if [ $output != 13 ]; then
+    printf >&2 'Failed to enforce a rigid response to getpid()\n'
+    exit 2
+fi


### PR DESCRIPTION
I went with the runtime environment variable being FAKETIME_FAKEPID
since it seems less likely to collide with anything else.

Closes: #297

Note: this is a work in progress, and a proof of concept.  i haven't done any more significant testing, and i suspect it's still vulnerable to failures in library initialization routines when `FAKETIME_FAKEPID` is unset, a la #295.

Just wanted to offer patches for consideration