### PR TITLE
Ensure that real_getrandom is initialized properly

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -3684,6 +3684,10 @@ ssize_t getrandom(void *buf, size_t buflen, unsigned int flags) {
     return buflen;
   }
   else { /* if no FAKERANDOM_SEED was given, use the original function */
+    if (!initialized)
+      {
+        ftpl_init();
+      }
     return real_getrandom(buf, buflen, flags);
   }
 }


### PR DESCRIPTION
This avoids potential failure if another library calls getrandom()
within its constructor before we are loaded.

For me, it lets "make randomtest" succeed in tests/

Closes: #295