### PR TITLE
Test getpid() against a library that invokes getpid() in its constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@
 *.so.1
 timetest
 test/getrandom_test
-test/librandom.o
-test/librandom.so
+test/lib*.o
+test/lib*.so
 test/use_lib_random
 
 src/libfaketime.dylib.1

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ test/getrandom_test
 test/lib*.o
 test/lib*.so
 test/use_lib_random
+test/use_lib_getpid
 
 src/libfaketime.dylib.1
 src/libfaketime.1.dylib

--- a/test/Makefile
+++ b/test/Makefile
@@ -28,6 +28,9 @@ functest:
 randomtest: getrandom_test use_lib_random librandom.so
 	./randomtest.sh
 
+getpidtest: use_lib_getpid libgetpid.so
+	./pidtest.sh
+
 lib%.o: lib%.c
 	${CC} -c -o $@ -fpic ${CFLAGS} $<
 
@@ -38,7 +41,7 @@ use_lib_%: use_lib_%.c lib%.so
 	${CC} -L. -o $@ ${CFLAGS}  $< -l$*
 
 clean:
-	@rm -f ${OBJ} timetest getrandom_test lib*.o lib*.so use_lib_random
+	@rm -f ${OBJ} timetest getrandom_test lib*.o lib*.so use_lib_random use_lib_getpid
 
 distclean: clean
 	@echo

--- a/test/Makefile
+++ b/test/Makefile
@@ -25,7 +25,7 @@ functest:
 getrandom_test: getrandom_test.c
 	${CC} -o $@ ${CFLAGS} $<
 
-randomtest: getrandom_test use_lib_random
+randomtest: getrandom_test use_lib_random librandom.so
 	./randomtest.sh
 
 librandom.o: librandom.c

--- a/test/Makefile
+++ b/test/Makefile
@@ -22,23 +22,23 @@ test: timetest functest
 functest:
 	./testframe.sh functests
 
-getrandom_test: getrandom_test.c
+%_test: %_test.c
 	${CC} -o $@ ${CFLAGS} $<
 
 randomtest: getrandom_test use_lib_random librandom.so
 	./randomtest.sh
 
-librandom.o: librandom.c
+lib%.o: lib%.c
 	${CC} -c -o $@ -fpic ${CFLAGS} $<
 
-librandom.so: librandom.o
+lib%.so: lib%.o
 	${CC} -o $@ -shared ${CFLAGS} $<
 
-use_lib_random: use_lib_random.c librandom.so
-	${CC} -L. -o $@ ${CFLAGS}  $< -lrandom
+use_lib_%: use_lib_%.c lib%.so
+	${CC} -L. -o $@ ${CFLAGS}  $< -l$*
 
 clean:
-	@rm -f ${OBJ} timetest getrandom_test librandom.o librandom.so use_lib_random
+	@rm -f ${OBJ} timetest getrandom_test lib*.o lib*.so use_lib_random
 
 distclean: clean
 	@echo

--- a/test/libgetpid.c
+++ b/test/libgetpid.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+void getpid_func() {
+  fprintf(stderr, "  called getpid_func()\n");
+}
+
+
+static __attribute__((constructor)) void getpid_init() {
+  pid_t pid = getpid();
+  fprintf(stderr, "  getpid() yielded %d\n", pid);
+}

--- a/test/libgetpid.h
+++ b/test/libgetpid.h
@@ -1,0 +1,6 @@
+#ifndef __LIBGETPID_H__
+#define __LIBGETPID_H__
+
+extern void getpid_func();
+
+#endif

--- a/test/pidtest.sh
+++ b/test/pidtest.sh
@@ -17,3 +17,10 @@ if [ $output != 13 ]; then
     printf >&2 'Failed to enforce a rigid response to getpid()\n'
     exit 2
 fi
+
+printf 'testing shared object with getpid() in library constructor\n'
+LD_LIBRARY_PATH=. ./use_lib_getpid
+printf 'now with LD_PRELOAD and FAKETIME_FAKEPID\n'
+FAKETIME_FAKEPID=25 LD_PRELOAD="$FTPL" LD_LIBRARY_PATH=. ./use_lib_getpid
+printf 'now with LD_PRELOAD without FAKETIME_FAKEPID\n'
+LD_PRELOAD="$FTPL" LD_LIBRARY_PATH=. ./use_lib_getpid

--- a/test/use_lib_getpid.c
+++ b/test/use_lib_getpid.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include "libgetpid.h"
+
+int main() {
+  pid_t pid;
+  getpid_func();
+  pid = getpid();
+  fprintf(stderr, " getpid() -> %d\n", pid);
+  return 0;
+}


### PR DESCRIPTION
This tries to address concerns raised in #295 and #297 about getpid and ill-timed calls from other library constructors.  (there's an additional minor fix for the `getrandom` test of the same situation as well)