### PR TITLE
Intercept syscall

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -44,6 +44,10 @@
 #     FAKE_PID
 #         - Intercept getpid()
 #
+#     INTERCEPT_SYSCALL
+#         - (On GNU/Linux only) intercept glibc's syscall() for known relevant syscalls.
+#           If enabled, this currently only works to divert the getrandom syscall.
+#
 #     FORCE_MONOTONIC_FIX
 #         - If the test program hangs forever on
 #                  " pthread_cond_timedwait: CLOCK_MONOTONIC test

--- a/test/Makefile
+++ b/test/Makefile
@@ -31,6 +31,9 @@ randomtest: getrandom_test use_lib_random librandom.so
 getpidtest: use_lib_getpid libgetpid.so
 	./pidtest.sh
 
+syscalltest: syscall_test
+	./syscalltest.sh
+
 lib%.o: lib%.c
 	${CC} -c -o $@ -fpic ${CFLAGS} $<
 

--- a/test/syscall_test.c
+++ b/test/syscall_test.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+
+int main() {
+  int d = 0;
+  long r = syscall(__NR_getrandom, &d, sizeof(d), 0);
+  printf("getrandom(%d, <ptr>, %zd, 0) returned %ld and yielded 0x%08x\n",
+         __NR_getrandom, sizeof(d), r, d);
+  return 0;
+}

--- a/test/syscalltest.sh
+++ b/test/syscalltest.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+FTPL="${FAKETIME_TESTLIB:-../src/libfaketime.so.1}"
+
+set -e
+
+error=0
+run0=$(./syscall_test)
+run1=$(LD_PRELOAD="$FTPL" ./syscall_test)
+run2=$(FAKERANDOM_SEED=0x0000000000000000 LD_PRELOAD="$FTPL" ./syscall_test)
+run3=$(FAKERANDOM_SEED=0x0000000000000000 LD_PRELOAD="$FTPL" ./syscall_test)
+run4=$(FAKERANDOM_SEED=0xDEADBEEFDEADBEEF LD_PRELOAD="$FTPL" ./syscall_test)
+
+if [ "$run0" = "$run1" ] ; then
+    error=1
+    printf >&2 'test run without LD_PRELOAD matches run with LD_PRELOAD.  This is very unlikely.\n'
+fi
+if [ "$run1" = "$run2" ] ; then
+    error=2
+    printf >&2 'test with LD_PRELOAD but without FAKERANDOM_SEED matches run with LD_PRELOAD and FAKERANDOM_SEED.  This is also very unlikely.\n'
+fi
+if [ "$run2" != "$run3" ]; then
+    error=1
+    printf >&2 'test run with same seed produces different outputs.\n'
+fi
+if [ "$run3" = "$run4" ]; then
+    error=1
+    printf >&2 'test runs with different seeds produce the same outputs.\n'
+fi


### PR DESCRIPTION
This is an attempt at an implementation to address #301.

Some things worth noting:

 - I am not particularly confident in my reverse of the variadic C
   ABI. While the code appears to work for me on x86_64, I could
   imagine some variations between platforms that I'm not
   understanding.

 - This works to intercept the invocation of syscall as seen in
   test/syscalltest.sh, as long as it was compiled with -DFAKE_RANDOM

 - defining -DINTERCEPT_SYSCALL on non-Linux platforms should result
   in a compile-time error.

 - This does *not* work to intercept the syscall sent by `openssl
   rand`, for some reason I don't yet understand.  Perhaps openssl has
   some platform-specific syscall mechanism that doesn't route them
   through libc's syscall() shim?