### PR TITLE
faketime: add -p option to wrapper for setting PID

### DIFF
--- a/man/faketime.1
+++ b/man/faketime.1
@@ -23,6 +23,9 @@ show version information and quit.
 \fB\-m\fR
 use the multi-threading variant of libfaketime.
 .TP
+\fB\-p <PID>\fR
+pretend that the program's process ID is PID. (only available if built with FAKE_PID)
+.TP
 \fB\-f\fR
 use the advanced timestamp specification format.
 .TP

--- a/src/faketime.c
+++ b/src/faketime.c
@@ -75,6 +75,9 @@ void usage(const char *name)
   "  -m                  : Use the multi-threaded version of libfaketime\n"
   "  -f                  : Use the advanced timestamp specification format (see manpage)\n"
   "  --exclude-monotonic : Prevent monotonic clock from drifting (not the raw monotonic one)\n"
+#ifdef FAKE_PID
+  "  -p PID              : Pretend that the program's process ID is PID\n"
+#endif
   "\n"
   "Examples:\n"
   "%s 'last friday 5 pm' /bin/date\n"
@@ -107,6 +110,8 @@ int main (int argc, char **argv)
   int curr_opt = 1;
   bool use_mt = false, use_direct = false;
   long offset;
+  bool fake_pid = false;
+  const char *pid_val;
 
   while(curr_opt < argc)
   {
@@ -114,6 +119,16 @@ int main (int argc, char **argv)
     {
       use_mt = true;
       curr_opt++;
+      continue;
+    }
+    if (0 == strcmp(argv[curr_opt], "-p"))
+    {
+      fake_pid = true;
+      pid_val = argv[curr_opt + 1];
+      curr_opt += 2;
+#ifndef FAKE_PID
+      fprintf(stderr, "faketime: -p argument probably won't work (try rebuilding with -DFAKE_PID)\n");
+#endif
       continue;
     }
     else if (0 == strcmp(argv[curr_opt], "-f"))
@@ -198,6 +213,8 @@ int main (int argc, char **argv)
     /* simply pass format string along */
     setenv("FAKETIME", argv[curr_opt], true);
   }
+  if (fake_pid)
+    setenv("FAKETIME_FAKEPID", pid_val, true);
   int keepalive_fds[2];
   (void) (pipe(keepalive_fds) + 1);
 


### PR DESCRIPTION
I had to decide what to do if FAKE_PID wasn't defined during the
build. I decided that since the wrapper can't be sure it is preloading
the same library that it was built with (someone could somehow mix and
match the library and the wrapper tool), it should just warn and pass
along the value anyway.

This reserves the option space, but shouldn't annoy people too much if
they are running it on a system that doesn't have FAKE_PID enabled.

I note that this happens regardless of whether it is a "direct"
invocation or not.  I don't fully understand all the tradeoffs here,
so I would appreciate another set of eyes reviewing this choice.

Closes: #308