### PR TITLE
Pass through syscall(__NR_clock_gettime) if FAKERANDOM is unset

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -3772,7 +3772,7 @@ long syscall(long number, ...) {
   }
 #endif
 // static int (*real_clock_gettime) (clockid_t clk_id, struct timespec *tp);
-  if (number == __NR_clock_gettime) {
+  if (number == __NR_clock_gettime && getenv("FAKETIME")) {
     clockid_t clk_id;
     struct timespec *tp;
     clk_id = va_arg(ap, clockid_t);


### PR DESCRIPTION
If FAKERANDOM is unset, we were still intercepting syscall() and
passing it through to clock_gettime, rather than letting it fall
through to real_syscall.

That would have the effect of diverting syscall(__NR_clock_gettime,…)
into the libc invocation of clock_gettime(…) (via real_clock_gettime).
While that probably does the same thing, it's probably a mistake to do
such a diversion when FAKETIME is unset.