### PR TITLE
faketime.c: default to GNU date as "gdate" on Sun-related OSes

### DIFF
--- a/src/faketime.c
+++ b/src/faketime.c
@@ -50,7 +50,7 @@
 
 const char version[] = "0.9.9";
 
-#ifdef __APPLE__
+#if (defined __APPLE__) || (defined __sun)
 static const char *date_cmd = "gdate";
 #else
 static const char *date_cmd = "date";


### PR DESCRIPTION
Following up from issue #315, this PR fixes the default "date_cmd" for SunOS platforms. Since with illumos there are actually many distributions, with various userlands (even some GNU by default, but this is rare), it is probable that `date` is the old SVR5 one without the fancy GNU-`date` capabilities, provided by additional packages delivering a `gdate`.

That said, the high probability is not a 100% guarantee (distros do differ), so having a switch per #317 to help end-users is even better.