### PR TITLE
Do not store the timestamp in the gzip

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -6,7 +6,7 @@ all:
 
 install:
 	$(INSTALL) -Dm0644 faketime.1 "${DESTDIR}${PREFIX}/share/man/man1/faketime.1"
-	gzip -f "${DESTDIR}${PREFIX}/share/man/man1/faketime.1"
+	gzip -nf "${DESTDIR}${PREFIX}/share/man/man1/faketime.1"
 
 uninstall:
 	rm -f "${DESTDIR}${PREFIX}/share/man/man1/faketime.1.gz"


### PR DESCRIPTION
To make libfaketime reproducible don't embed the timestamp in the gzip
header.

Motivation: https://reproducible-builds.org