### PR TITLE
Add a build variable to opt-out of behaviors that reduce reliability

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@
 #   * Compilation Defines that are set by default:
 #
 #     FAKE_STAT
-#         - Enables time faking also for files' timestamps.
+#         - Enables time faking when reading files' timestamps.
 #
 #     FAKE_SLEEP
 #         - Also intercept sleep(), nanosleep(), usleep(), alarm(), [p]poll()
@@ -31,8 +31,9 @@
 #
 #     FAKE_FILE_TIMESTAMPS, FAKE_UTIME
 #         - Enables time faking for the utime* functions.  If enabled via
-#           FAKE_UTIME define instead of FAKE_FILE_TIMESTAMPS, the faking
-#           defaults to off without FAKE_UTIME in the environment.
+#           FAKE_FILE_TIMESTAMPS, the faking is opt-in at runtime using
+#           with the FAKE_UTIME environment variable. If enabled via
+#           FAKE_UTIME, the faking is opt-out at runtime.
 #
 #     NO_ATFILE
 #         - Disables support for the fstatat() group of functions

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,30 +1,10 @@
 #
 # Notes:
 #
-#   * Compilation Defines:
+#   * Compilation Defines that are set by default:
 #
 #     FAKE_STAT
 #         - Enables time faking also for files' timestamps.
-#
-#     FAKE_FILE_TIMESTAMPS, FAKE_UTIME
-#         - Enables time faking for the utime* functions.  If enabled via
-#           FAKE_UTIME define instead of FAKE_FILE_TIMESTAMPS, the faking
-#           defaults to off without FAKE_UTIME in the environment.
-#
-#     NO_ATFILE
-#         - Disables support for the fstatat() group of functions
-#
-#     PTHREAD_SINGLETHREADED_TIME
-#         - Define this if you want to single-thread time() ... there ARE
-#           possible caching side-effects in a multithreaded environment
-#           without this, but the performance impact may require you to
-#           try it unsynchronized.
-#
-#     FAKE_INTERNAL_CALLS
-#         - Also intercept libc internal __functions, e.g. not just time(),
-#           but also __time(). Enhances compatibility with applications
-#           that make use of low-level system calls, such as Java Virtual
-#           Machines.
 #
 #     FAKE_SLEEP
 #         - Also intercept sleep(), nanosleep(), usleep(), alarm(), [p]poll()
@@ -34,6 +14,28 @@
 #
 #     FAKE_PTHREAD
 #         - Intercept pthread_cond_timedwait
+#
+#     FAKE_INTERNAL_CALLS
+#         - Also intercept libc internal __functions, e.g. not just time(),
+#           but also __time(). Enhances compatibility with applications
+#           that make use of low-level system calls, such as Java Virtual
+#           Machines.
+#
+#     PTHREAD_SINGLETHREADED_TIME (only set in libfaketimeMT.so)
+#         - Define this if you want to single-thread time() ... there ARE
+#           possible caching side-effects in a multithreaded environment
+#           without this, but the performance impact may require you to
+#           try it unsynchronized.
+#
+#   * Compilation Defines that are unset by default:
+#
+#     FAKE_FILE_TIMESTAMPS, FAKE_UTIME
+#         - Enables time faking for the utime* functions.  If enabled via
+#           FAKE_UTIME define instead of FAKE_FILE_TIMESTAMPS, the faking
+#           defaults to off without FAKE_UTIME in the environment.
+#
+#     NO_ATFILE
+#         - Disables support for the fstatat() group of functions
 #
 #     FAKE_SETTIME
 #         - Intercept clock_settime(), settimeofday(), and adjtime()

--- a/src/Makefile
+++ b/src/Makefile
@@ -56,6 +56,17 @@
 #           -Dvariadic_promotion_t=int into CFLAGS).  See src/faketime_common.h for
 #           more info.
 #
+#     FAKE_STATELESS
+#         - Remove support for any functionality that requires sharing state across
+#           threads of a process, or different processes. This decreases the risk of
+#           interference with a program's normal execution, at the cost of supporting
+#           fewer ways of specifying the time.
+#           Concretely, this currently:
+#           - disables PTHREAD_SINGLETHREADED_TIME, which can cause deadlocks in
+#             multithreaded programs that fork due to making clock_gettime not
+#             async-signal-safe
+#           - disables all shared-memory across processes
+#
 #     FORCE_MONOTONIC_FIX
 #         - If the test program hangs forever on
 #                  " pthread_cond_timedwait: CLOCK_MONOTONIC test

--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -60,6 +60,9 @@
 #include "time_ops.h"
 #include "faketime_common.h"
 
+#if defined PTHREAD_SINGLETHREADED_TIME && defined FAKE_STATELESS
+#undef PTHREAD_SINGLETHREADED_TIME
+#endif
 
 /* pthread-handling contributed by David North, TDI in version 0.7 */
 #if defined PTHREAD_SINGLETHREADED_TIME || defined FAKE_PTHREAD
@@ -2652,7 +2655,11 @@ static void ftpl_init(void)
 
   initialized = 1;
 
+#ifdef FAKE_STATELESS
+  if (0) ft_shm_init();
+#else
   ft_shm_init();
+#endif
 #ifdef FAKE_STAT
   if (getenv("NO_FAKE_STAT")!=NULL)
   {


### PR DESCRIPTION
(this is based on a sibling pull request, only the last commit is really part of this pull request)

Provide a way to get libfaketime to not initialize a shared memory segment.

For reasons that I didn't dig into, the shared memory setup fails when wrapping something that does a ton of process spawning (a build system). I have patched it out of my build of libfaketime for months as a result, because it's just not needed when simply changing time by a fixed offset, for instance.

This new variable also unsets PTHREAD_SINGLETHREADED_TIME, which is not strictly necessary as that can already be disabled, but this is also a reliability hazard due to potentially creating deadlocks, so I think it makes sense to disable it in this case too.