### PR TITLE
fix do/while guard for DONT_FAKE_TIME macro

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -148,7 +148,7 @@ static __thread bool dont_fake = false;
 
 /* Wrapper for function calls, which we want to return system time */
 #define DONT_FAKE_TIME(call)          \
-  {                                   \
+  do {                                \
     bool dont_fake_orig = dont_fake;  \
     if (!dont_fake)                   \
     {                                 \


### PR DESCRIPTION
the newer version gcc warns `this ‘while’ clause does not guard... [-Werror=misleading-indentation]`. looks like the author just omitted the `do` and the `while(0)` counts as a separate statement.

in practice this isn't causing any actual problem now afaict.