### PR TITLE
formatting cleanups

### DIFF
--- a/man/faketime.1
+++ b/man/faketime.1
@@ -7,11 +7,11 @@ faketime \- manipulate the system time for a given command
 .SH DESCRIPTION
 .\" \fIfaketime\fR will trick the given program into seeing the specified timestamp as its starting date and time.
 .PP
-The given command will be tricked into believing that the current system time is the one specified in the timestamp. Filesystem timestamps will also be
-reported relative to this timestamp. The wall clock will continue to run from this date and time unless specified otherwise (see advanced options).
-Actually, faketime is a simple wrapper for libfaketime, which uses the LD_PRELOAD mechanism to load a small library which intercepts system calls to
-functions such as \fItime(2)\fR and \fIfstat(2)\fR. This wrapper exposes only a subset of libfaketime's functionality; please refer to the README file
-that came with faketime for more details and advanced options, or have a look at http://github.com/wolfcw/libfaketime
+The given command will be tricked into believing that the current system time is the one specified in the timestamp.
+Filesystem timestamps will also be reported relative to this timestamp.
+The wall clock will continue to run from this date and time unless specified otherwise (see advanced options).
+Actually, faketime is a simple wrapper for libfaketime, which uses the LD_PRELOAD mechanism to load a small library which intercepts system calls to functions such as \fItime(2)\fR and \fIfstat(2)\fR.
+This wrapper exposes only a subset of libfaketime's functionality; please refer to the README file that came with faketime for more details and advanced options, or have a look at http://github.com/wolfcw/libfaketime
 .SH OPTIONS
 .TP
 \fB\-\-help\fR
@@ -33,9 +33,7 @@ use the advanced timestamp specification format.
 Do not fake time when the program makes a call to clock_gettime with a CLOCK_MONOTONIC clock.
 .TP
 \fB\--date-prog <PATH>\fR
-Use a specific GNU-date compatible implementation of the helper used to
-transform "timestamp format" strings into programmatically usable dates,
-instead of a compile-time default guess for the generic target platform.
+Use a specific GNU-date compatible implementation of the helper used to transform "timestamp format" strings into programmatically usable dates, instead of a compile-time default guess for the generic target platform.
 
 .SH EXAMPLES
 .nf
@@ -49,41 +47,53 @@ In this single case all spawned processes will use the same global clock without
 (Please note that it depends on your locale settings whether . or , has to be used for fractional offsets)
 .fi
 .SH ADVANCED TIMESTAMP FORMAT
-The simple timestamp format used by default applies the \fB/bin/date -d\fR command to parse user-friendly specifications such as 'last friday'. When using
-the faketime option \fB\-f\fR, the timestamp specified on the command line is directly passed to libfaketime, which enables a couple of additional features
-such as speeding the clock up or slowing it down for the target program. It is strongly recommended that you have a look at the libfaketime documentation. Summary:
+The simple timestamp format used by default applies the \fB/bin/date -d\fR command to parse user-friendly specifications such as 'last friday'.
+When using the faketime option \fB\-f\fR, the timestamp specified on the command line is directly passed to libfaketime, which enables a couple of additional features such as speeding the clock up or slowing it down for the target program.
+It is strongly recommended that you have a look at the libfaketime documentation.
+Summary:
 .TP
 Freeze clock at absolute timestamp: \fB"YYYY-MM-DD hh:mm:ss"\fR
-If you want to specify an absolute point in time, exactly this format must be used. Please note that freezing the clock is usually not what you want and may break the application. Only use if you know what you're doing!
+If you want to specify an absolute point in time, exactly this format must be used.
+Please note that freezing the clock is usually not what you want and may break the application.
+Only use if you know what you're doing!
 .TP
 Relative time offset: \fB"[+/-]123[m/h/d/y]\fR, e.g. "+60m", "+2y"
-This is the most often used format and specifies the faked time relatively to the current real time. The first character of the format string \fBmust\fR be a + or a -. The numeric value by default represents seconds, but the modifiers m, h, d, and y can be used to specify minutes, hours, days, or years, respectively. For example, "-2y" means "two years ago". Fractional time offsets can be used, e.g. "+2,5y", which means "two and a half years in the future". Please note that the fraction delimiter depends on your locale settings, so if "+2,5y" does not work, you might want to try "+2.5y".
+This is the most often used format and specifies the faked time relatively to the current real time.
+The first character of the format string \fBmust\fR be a + or a -.
+The numeric value by default represents seconds, but the modifiers m, h, d, and y can be used to specify minutes, hours, days, or years, respectively.
+For example, "-2y" means "two years ago". Fractional time offsets can be used, e.g. "+2,5y", which means "two and a half years in the future".
+Please note that the fraction delimiter depends on your locale settings, so if "+2,5y" does not work, you might want to try "+2.5y".
 .TP
 Start-at timestamps: \fB"@YYYY-MM-DD hh:mm:ss"\fR
-The wall clock will start counting at the given timestamp for the program. This can be used for specifying absolute timestamps without freezing the clock.
+The wall clock will start counting at the given timestamp for the program.
+This can be used for specifying absolute timestamps without freezing the clock.
 .SH ADVANCED USAGE
-When using relative time offsets or start-at timestamps (see ADVANCED TIMESTAMP FORMAT above and option \fB\-f\fR), the clock speed can be adjusted, i.e. time may run faster or slower for the executed program. For example, \fB"+5y x10"\fR will set the faked time 5 years into the future and make the time pass 10 times as fast (one real second equals 10 seconds measured by the program). Similarly, the flow of time can be slowed, e.g. using \fB"-7d x0,2"\fR, which will set the faked time 7 days in the past and set the clock speed to 20 percent, i.e. it takes five real world seconds for one second measured by the program. Again, depending on your locale, either "x2.0" or "x2,0" may be required regarding the delimiter. You can also make faketime to advance the reported time by a preset interval upon each time() call independently from the system's time using \fB"-7d i2,0"\fR, where
-\fB"i"\fR is followed by the increase interval in seconds.
+When using relative time offsets or start-at timestamps (see ADVANCED TIMESTAMP FORMAT above and option \fB\-f\fR), the clock speed can be adjusted, i.e. time may run faster or slower for the executed program.
+For example, \fB"+5y x10"\fR will set the faked time 5 years into the future and make the time pass 10 times as fast (one real second equals 10 seconds measured by the program).
+Similarly, the flow of time can be slowed, e.g. using \fB"-7d x0,2"\fR, which will set the faked time 7 days in the past and set the clock speed to 20 percent, i.e. it takes five real world seconds for one second measured by the program.
+Again, depending on your locale, either "x2.0" or "x2,0" may be required regarding the delimiter.
+You can also make faketime to advance the reported time by a preset interval upon each time() call independently from the system's time using \fB"-7d i2,0"\fR, where \fB"i"\fR is followed by the increase interval in seconds.
 .PP
-Faking times for multiple programs or even system-wide can be simplified by using ~/.faketimerc files and /etc/faketimerc. Please refer to the README that came with faketime for warnings and details.
+Faking times for multiple programs or even system-wide can be simplified by using ~/.faketimerc files and /etc/faketimerc.
+Please refer to the README that came with faketime for warnings and details.
 .PP
 Faking of filesystem timestamps may be disabled by setting the NO_FAKE_STAT environment variable to a non-empty value.
 .SH AUTHOR
 Please see the README and NEWS files for contributors.
 .SH BUGS
 Due to limitations of the LD_PRELOAD mechanism, faketime will not work with suidroot and statically linked programs.
-While timestamps and time offsets will work for child processes, speeding the clock up or slowing it down might not
-work for child processes spawned by the executed program as expected; a new instance of libfaketime is used for each
-child process, which means that the libfaketime start time, which is used in speed adjustments, will also be
-re-initialized. Some programs may dynamically load system libraries, such as librt, at run-time and therefore bypass libfaketime. You may report programs that do not work with libfaketime, but only if they are available as open source.
+While timestamps and time offsets will work for child processes, speeding the clock up or slowing it down might not work for child processes spawned by the executed program as expected;
+a new instance of libfaketime is used for each child process, which means that the libfaketime start time, which is used in speed adjustments, will also be re-initialized.
+Some programs may dynamically load system libraries, such as librt, at run-time and therefore bypass libfaketime.
+You may report programs that do not work with libfaketime, but only if they are available as open source.
 .SH "REPORTING BUGS"
 Please use https://github.com/wolfcw/libfaketime/issues
 .SH COPYRIGHT
 Copyright \(co 2003-2021 by the libfaketime authors.
 .PP
-There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE. You may redistribute copies of faketime under the
-terms of the GNU General Public License.
+There is NO warranty;
+not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+You may redistribute copies of faketime under the terms of the GNU General Public License.
 .br
 For more information about these matters, see the file named COPYING.
 .SH "SEE ALSO"

--- a/man/faketime.1
+++ b/man/faketime.1
@@ -11,7 +11,7 @@ The given command will be tricked into believing that the current system time is
 Filesystem timestamps will also be reported relative to this timestamp.
 The wall clock will continue to run from this date and time unless specified otherwise (see advanced options).
 Actually, faketime is a simple wrapper for libfaketime, which uses the LD_PRELOAD mechanism to load a small library which intercepts system calls to functions such as \fItime(2)\fR and \fIfstat(2)\fR.
-This wrapper exposes only a subset of libfaketime's functionality; please refer to the README file that came with faketime for more details and advanced options, or have a look at http://github.com/wolfcw/libfaketime
+This wrapper exposes only a subset of libfaketime's functionality; please refer to the README file that came with faketime for more details and advanced options, or have a look at https://github.com/wolfcw/libfaketime
 .SH OPTIONS
 .TP
 \fB\-\-help\fR
@@ -57,20 +57,20 @@ If you want to specify an absolute point in time, exactly this format must be us
 Please note that freezing the clock is usually not what you want and may break the application.
 Only use if you know what you're doing!
 .TP
-Relative time offset: \fB"[+/-]123[m/h/d/y]\fR, e.g. "+60m", "+2y"
+Relative time offset: \fB"[+/-]123[m/h/d/y]"\fR, e.g., "+60m", "+2y"
 This is the most often used format and specifies the faked time relatively to the current real time.
 The first character of the format string \fBmust\fR be a + or a -.
 The numeric value by default represents seconds, but the modifiers m, h, d, and y can be used to specify minutes, hours, days, or years, respectively.
-For example, "-2y" means "two years ago". Fractional time offsets can be used, e.g. "+2,5y", which means "two and a half years in the future".
+For example, "-2y" means "two years ago". Fractional time offsets can be used, e.g., "+2,5y", which means "two and a half years in the future".
 Please note that the fraction delimiter depends on your locale settings, so if "+2,5y" does not work, you might want to try "+2.5y".
 .TP
 Start-at timestamps: \fB"@YYYY-MM-DD hh:mm:ss"\fR
 The wall clock will start counting at the given timestamp for the program.
 This can be used for specifying absolute timestamps without freezing the clock.
 .SH ADVANCED USAGE
-When using relative time offsets or start-at timestamps (see ADVANCED TIMESTAMP FORMAT above and option \fB\-f\fR), the clock speed can be adjusted, i.e. time may run faster or slower for the executed program.
+When using relative time offsets or start-at timestamps (see ADVANCED TIMESTAMP FORMAT above and option \fB\-f\fR), the clock speed can be adjusted, i.e., time may run faster or slower for the executed program.
 For example, \fB"+5y x10"\fR will set the faked time 5 years into the future and make the time pass 10 times as fast (one real second equals 10 seconds measured by the program).
-Similarly, the flow of time can be slowed, e.g. using \fB"-7d x0,2"\fR, which will set the faked time 7 days in the past and set the clock speed to 20 percent, i.e. it takes five real world seconds for one second measured by the program.
+Similarly, the flow of time can be slowed, e.g., using \fB"-7d x0,2"\fR, which will set the faked time 7 days in the past and set the clock speed to 20 percent, i.e., it takes five real world seconds for one second measured by the program.
 Again, depending on your locale, either "x2.0" or "x2,0" may be required regarding the delimiter.
 You can also make faketime to advance the reported time by a preset interval upon each time() call independently from the system's time using \fB"-7d i2,0"\fR, where \fB"i"\fR is followed by the increase interval in seconds.
 .PP

--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -612,7 +612,7 @@ static void get_fake_monotonic_setting(int* current_value)
 static void system_time_from_system (struct system_time_s * systime)
 {
 #ifdef __APPLEOSX__
-  /* from http://stackoverflow.com/questions/5167269/clock-gettime-alternative-in-mac-os-x */
+  /* from https://stackoverflow.com/questions/5167269/clock-gettime-alternative-in-mac-os-x */
   clock_serv_t cclock;
   mach_timespec_t mts;
   host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &clock_serv_real);


### PR DESCRIPTION
This is a nonsubstantive change, just a few minor formatting and grammar and link fixups.

The biggest visible change is the nroff source for `man/faketime.1`, which is now one sentence per line, a format that is easier to read and simpler to review in a line-by-line diff.