### PR TITLE
Avoid spurious "Success" error message.

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -2374,8 +2374,8 @@ static void parse_ft_string(const char *user_faked_time)
       }
       else
       {
-        perror("libfaketime: In parse_ft_string(), failed to parse FAKETIME timestamp");
-        fprintf(stderr, "Please check specification %s with format %s\n", user_faked_time, user_faked_time_fmt);
+        fprintf(stderr, "libfaketime: In parse_ft_string(), failed to parse FAKETIME timestamp.\n"
+                "Please check specification %s with format %s\n", user_faked_time, user_faked_time_fmt);
         exit(EXIT_FAILURE);
       }
       break;
@@ -2418,7 +2418,7 @@ static void parse_ft_string(const char *user_faked_time)
       }
       else
       {
-        perror("libfaketime: In parse_ft_string(), failed to parse FAKETIME timestamp");
+        fprintf(stderr, "libfaketime: In parse_ft_string(), failed to parse FAKETIME timestamp.\n");
         exit(EXIT_FAILURE);
       }
 


### PR DESCRIPTION
strptime(3) doesn't set errno, so when it was failing, calling perror()
meant producing messages like:

Failed to parse FAKETIME timestamp: Success

Rather than use perror(), just send the warning message directly to
stderr.

This was first reported in https://bugs.debian.org/939789