### PR TITLE
libfaketime: Set 777 on shared memory

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -413,12 +413,12 @@ static void ft_shm_create(void) {
 #endif
   snprintf(sem_name, 255, "/faketime_sem_%ld", (long)pid);
   snprintf(shm_name, 255, "/faketime_shm_%ld", (long)pid);
-  if (SEM_FAILED == (semN = sem_open(sem_name, O_CREAT|O_EXCL, S_IWUSR|S_IRUSR, 1)))
+  if (SEM_FAILED == (semN = sem_open(sem_name, O_CREAT|O_EXCL, S_IRWXU | S_IRWXO | S_IRWXG, 1)))
   { /* silently fail on platforms that do not support sem_open() */
     return;
   }
   /* create shm */
-  if (-1 == (shm_fdN = shm_open(shm_name, O_CREAT|O_EXCL|O_RDWR, S_IWUSR|S_IRUSR)))
+  if (-1 == (shm_fdN = shm_open(shm_name, O_CREAT|O_EXCL|O_RDWR, S_IRWXU | S_IRWXO | S_IRWXG)))
   {
     perror("libfaketime: In ft_shm_create(), shm_open failed");
     exit(EXIT_FAILURE);
@@ -576,7 +576,7 @@ static void ft_shm_init (void)
       }
     }
 
-    if (-1 == (ticks_shm_fd = shm_open(shm_name, O_CREAT|O_RDWR, S_IWUSR|S_IRUSR)))
+    if (-1 == (ticks_shm_fd = shm_open(shm_name, O_CREAT|O_RDWR, S_IRWXU | S_IRWXO | S_IRWXG)))
     {
       perror("libfaketime: In ft_shm_init(), shm_open failed");
       exit(1);
@@ -2693,7 +2693,9 @@ static void ftpl_init(void)
 #ifdef FAKE_STATELESS
   if (0) ft_shm_init();
 #else
+  mode_t oldmask = umask(0);
   ft_shm_init();
+  umask(oldmask);
 #endif
 #ifdef FAKE_STAT
   if (getenv("NO_FAKE_STAT")!=NULL)


### PR DESCRIPTION
I've been playing around with libfaketime PRELOAD'ed in docker. It seems that whenever 'su' is involved things tend to break with semaphore permissions problems. This aims to fix it by making shared memory world-accessible. It's somewhat a security risk, but come on, nobody should ever be using this in production environments anyway! 

And for testing this doesn't really matter ;)

In other words, how to use it to send a whole docker container back (or forth) in time:

```
echo "-1d x1,0" > /etc/faketimerc
chmod -Rfv u+s /usr/local/lib/faketime/*
echo "/usr/local/lib/faketime/" > /etc/ld.so.conf.d/90-faketime.conf
ldconfig
echo "libfaketimeMT.so.1" > /etc/ld.so.preload
```

Signed-off-by: Andrew Andrianov <andrew@ncrmnt.org>