### PR TITLE
clean up tests related to syscall

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -7,7 +7,7 @@ SRC = timetest.c
 OBJ = ${SRC:.c=.o}
 
 TEST_SNIPPETS = $(notdir $(basename $(wildcard snippets/*.c)))
-EXPECTATIONS= $(notdir $(basename $(wildcard snippets/*.variable)))
+EXPECTATIONS = $(notdir $(basename $(wildcard snippets/*.variable)))
 
 ALL_TESTS = timetest test
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,6 +13,9 @@ ALL_TESTS = timetest test
 
 ifneq ($(filter -DINTERCEPT_SYSCALL,${CFLAGS}),)
 ALL_TESTS += confirm_variadic_promotion
+else
+TEST_SNIPPETS := $(filter-out syscall%,${TEST_SNIPPETS})
+EXPECTATIONS := $(filter-out syscall%,${EXPECTATIONS})
 endif
 
 all: $(ALL_TESTS)


### PR DESCRIPTION
When `-DINTERCEPT_SYSCALL` is not set, the test suite currently still tests snippets related to syscall when invoked with `make test_variable_data` from the `test/` directory.  Sorry i missed this before.

This is what was the proximate cause of https://bugs.debian.org/1007828