### PR TITLE
Work-around / fix libasan incompatibility

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -27,6 +27,11 @@
 #           without this, but the performance impact may require you to
 #           try it unsynchronized.
 #
+#     FAIL_PRE_INIT_CALLS
+#         - If the time is queried before the library was initialised, let the
+#           call fail instead of trying to initialise on-the-fly. This fixes /
+#           works around hangs that were seen with address sanitizer.
+#
 #   * Compilation Defines that are unset by default:
 #
 #     FAKE_FILE_TIMESTAMPS, FAKE_UTIME
@@ -110,7 +115,7 @@ PREFIX ?= /usr/local
 LIBDIRNAME ?= /lib/faketime
 PLATFORM ?=$(shell uname)
 
-CFLAGS += -std=gnu99 -Wall -Wextra -Werror -Wno-nonnull-compare -DFAKE_PTHREAD -DFAKE_STAT -DFAKE_UTIME -DFAKE_SLEEP -DFAKE_TIMERS -DFAKE_INTERNAL_CALLS -fPIC -DPREFIX='"'$(PREFIX)'"' -DLIBDIRNAME='"'$(LIBDIRNAME)'"' $(FAKETIME_COMPILE_CFLAGS)
+CFLAGS += -std=gnu99 -Wall -Wextra -Werror -Wno-nonnull-compare -DFAKE_PTHREAD -DFAKE_STAT -DFAKE_UTIME -DFAKE_SLEEP -DFAKE_TIMERS -DFAKE_INTERNAL_CALLS -DFAIL_PRE_INIT_CALLS -fPIC -DPREFIX='"'$(PREFIX)'"' -DLIBDIRNAME='"'$(LIBDIRNAME)'"' $(FAKETIME_COMPILE_CFLAGS)
 ifeq ($(PLATFORM),SunOS)
 CFLAGS += -D__EXTENSIONS__ -D_XOPEN_SOURCE=600
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,11 +27,6 @@
 #           without this, but the performance impact may require you to
 #           try it unsynchronized.
 #
-#     FAIL_PRE_INIT_CALLS
-#         - If the time is queried before the library was initialised, let the
-#           call fail instead of trying to initialise on-the-fly. This fixes /
-#           works around hangs that were seen with address sanitizer.
-#
 #   * Compilation Defines that are unset by default:
 #
 #     FAKE_FILE_TIMESTAMPS, FAKE_UTIME
@@ -89,6 +84,11 @@
 #         - avoid that the faketime wrapper complains when running within a
 #           libfaketime environment
 #
+#     FAIL_PRE_INIT_CALLS
+#         - If the time is queried before the library was initialised, let the
+#           call fail instead of trying to initialise on-the-fly. This fixes /
+#           works around hangs that were seen with address sanitizer.
+#
 #   * Compilation addition: second libMT target added for building the pthread-
 #     enabled library as a separate library
 #
@@ -115,7 +115,7 @@ PREFIX ?= /usr/local
 LIBDIRNAME ?= /lib/faketime
 PLATFORM ?=$(shell uname)
 
-CFLAGS += -std=gnu99 -Wall -Wextra -Werror -Wno-nonnull-compare -DFAKE_PTHREAD -DFAKE_STAT -DFAKE_UTIME -DFAKE_SLEEP -DFAKE_TIMERS -DFAKE_INTERNAL_CALLS -DFAIL_PRE_INIT_CALLS -fPIC -DPREFIX='"'$(PREFIX)'"' -DLIBDIRNAME='"'$(LIBDIRNAME)'"' $(FAKETIME_COMPILE_CFLAGS)
+CFLAGS += -std=gnu99 -Wall -Wextra -Werror -Wno-nonnull-compare -DFAKE_PTHREAD -DFAKE_STAT -DFAKE_UTIME -DFAKE_SLEEP -DFAKE_TIMERS -DFAKE_INTERNAL_CALLS -fPIC -DPREFIX='"'$(PREFIX)'"' -DLIBDIRNAME='"'$(LIBDIRNAME)'"' $(FAKETIME_COMPILE_CFLAGS)
 ifeq ($(PLATFORM),SunOS)
 CFLAGS += -D__EXTENSIONS__ -D_XOPEN_SOURCE=600
 endif

--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -2282,6 +2282,16 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp)
   if (!initialized)
   {
     recursion_depth++;
+#ifdef FAIL_PRE_INIT_CALLS
+      fprintf(stderr, "libfaketime: clock_gettime() was called before initialization.\n");
+      fprintf(stderr, "libfaketime:  Returning -1 on clock_gettime().\n");
+      if (tp != NULL)
+      {
+        tp->tv_sec = 0;
+        tp->tv_nsec = 0;
+      }
+      return -1;
+#else
     if (recursion_depth == 2)
     {
       fprintf(stderr, "libfaketime: Unexpected recursive calls to clock_gettime() without proper initialization. Trying alternative.\n");
@@ -2302,6 +2312,7 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp)
     else {
       ftpl_init();
     }
+#endif
     recursion_depth--;
   }
   /* sanity check */

--- a/test/Makefile
+++ b/test/Makefile
@@ -76,7 +76,7 @@ use_lib_%: _use_lib_test.c snippets/%.c lib%.so
 ## cleanup and metainformation
 
 clean:
-	@rm -f ${OBJ} timetest getrandom_test syscall_test $(foreach f,${TEST_SNIPPETS},use_lib_${f} lib${f}.so run_${f}) variadic_promotion variadic/*.o repeat_random
+	@rm -f ${OBJ} timetest getrandom_test syscall_test $(foreach f,${TEST_SNIPPETS},use_lib_${f} lib${f}.so run_${f}) variadic_promotion variadic/*.o repeat_random libmallocintercept.so
 
 distclean: clean
 	@echo

--- a/test/Makefile
+++ b/test/Makefile
@@ -26,7 +26,7 @@ all: $(ALL_TESTS)
 timetest: ${OBJ}
 	${CC} -o $@ ${OBJ} ${LDFLAGS}
 
-test: timetest functest
+test: timetest functest libmallocintercept.so
 	@echo
 	@./test.sh
 
@@ -39,6 +39,9 @@ functest:
 
 randomtest: repeat_random
 	./randomtest.sh
+
+libmallocintercept.so: libmallocintercept.c
+	${CC} -shared -o $@ -fpic ${CFLAGS} $<
 
 # ensure our variadic argument unpacking/repacking works as expected
 confirm_variadic_promotion: variadic_promotion

--- a/test/libmallocintercept.c
+++ b/test/libmallocintercept.c
@@ -50,6 +50,7 @@ static void* actual_malloc(size_t size) {
 }
 
 static void poke_faketime(void) {
+#ifdef FAIL_PRE_INIT_CALLS
 	/* To complicate things for libfaketime, this calls clock_gettime()
 	 * while holding a lock. This should simulate problems that occurred
 	 * with address sanitizer.
@@ -60,6 +61,9 @@ static void poke_faketime(void) {
 	pthread_mutex_lock(&time_mutex);
 	clock_gettime(CLOCK_REALTIME, &timespec);
 	pthread_mutex_unlock(&time_mutex);
+#else
+	print_msg("FAIL_PRE_INIT_CALLS not defined, skipping poke_faketime() ");
+#endif
 }
 
 void *malloc(size_t size) {

--- a/test/libmallocintercept.c
+++ b/test/libmallocintercept.c
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (C) 2022 be.storaged GmbH
+ *
+ *  This file is part of libfaketime
+ *
+ *  libfaketime is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License v2 as published by the
+ *  Free Software Foundation.
+ *
+ *  libfaketime is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ *  more details.
+ *
+ *  You should have received a copy of the GNU General Public License v2 along
+ *  with the libfaketime; if not, write to the Free Software Foundation,
+ *  Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+static void print_msg(const char *msg) {
+	write(0, msg, strlen(msg));
+}
+
+static void* actual_malloc(size_t size) {
+	/* We would like to use "the real malloc", but cannot. Thus, this
+	 * implements a trivial, allocate-only bump allocator to make things
+	 * work.
+	 */
+	static char memory_arena[16 << 20];
+	static size_t allocated_index = 0;
+
+	void *result = &memory_arena[allocated_index];
+
+	allocated_index += size;
+	/* align to a multiple of 8 bytes */
+	allocated_index = (allocated_index + 7) / 8 * 8;
+
+	if (allocated_index >= sizeof(memory_arena)) {
+		print_msg("libmallocintercept is out of memory!");
+		abort();
+	}
+
+	return result;
+}
+
+static void poke_faketime(void) {
+	/* To complicate things for libfaketime, this calls clock_gettime()
+	 * while holding a lock. This should simulate problems that occurred
+	 * with address sanitizer.
+	 */
+	static pthread_mutex_t time_mutex = PTHREAD_MUTEX_INITIALIZER;
+	struct timespec timespec;
+
+	pthread_mutex_lock(&time_mutex);
+	clock_gettime(CLOCK_REALTIME, &timespec);
+	pthread_mutex_unlock(&time_mutex);
+}
+
+void *malloc(size_t size) {
+	print_msg("Called malloc() from libmallocintercept...");
+	poke_faketime();
+	print_msg("successfully\n");
+	return actual_malloc(size);
+}
+
+void free(void *) {
+	print_msg("Called free() from libmallocintercept...");
+	poke_faketime();
+	print_msg("successfully\n");
+
+	/* We cannot actually free memory */
+}
+

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 FTPL="${FAKETIME_TESTLIB:-../src/libfaketime.so.1}"
+MALLOC_INTERCEPT=./libmallocintercept.so
 
 if [ -f /etc/faketimerc ] ; then
 	echo "Running the test program with your system-wide default in /etc/faketimerc"
@@ -60,6 +61,14 @@ echo
 echo "Running the 'date' command with 15 days negative offset specified"
 echo "\$ LD_PRELOAD=$FTPL FAKETIME=\"-15d\" date"
 LD_PRELOAD="$FTPL" FAKETIME="-15d" date
+echo
+
+echo "============================================================================="
+echo
+
+echo "Running the test program with malloc interception"
+echo "\$ LD_PRELOAD=./libmallocintercept.so:$FTPL ./timetest"
+LD_PRELOAD="./libmallocintercept.so:$FTPL" ./timetest
 echo
 
 echo "============================================================================="


### PR DESCRIPTION
This is my attempt at fixing #365. I cleaned up the proposed patch from there and actually simplified it a bit. I also added a unit test that would previously hang (deadlock in `pthread_mutex_lock()`) and now passes.

As requested, this adds a new define. I chose to call it `FAIL_PRE_INIT_CALLS`. I also had to enable it by default since otherwise the test would hang. I kind of expect this to be an unsatisfactory solutions. Please advice how to properly integrate this test (or whether it should just be deleted).

I *did* test that this makes the hang with both `clang -fsanitize=address main.c` and `clang++ -fsanitize=address main.cpp` go away (where `main.c(pp)` is just an empty main function). I also checked that without this changes, the resulting programs would hang under faketime.

Fixes #365 

Edit: Also, I was lazy and just failed all calls before `ftpl_init()`, not only during `ftpl_init()`. That's different to the previous hacky patch.