### PR TITLE
test/snippets: fix time.c compiler error on 32-bit arches

### DIFF
--- a/test/snippets/time.c
+++ b/test/snippets/time.c
@@ -1,2 +1,2 @@
 time_t t = time(NULL);
-printf("[%s] time() yielded %zd\n", where, t);
+printf("[%s] time() yielded %lu\n", where, (unsigned long)t);


### PR DESCRIPTION
Cast t to unsigned long and use the %lu format specifier instead of %zd.
This is more portable to 32-bit arches, avoiding the following compiler
error:

 snippets/time.c:2:31: error: format ‘%zd’ expects argument of type ‘signed size_t’, but argument 3 has type ‘time_t’ {aka ‘long int’} [-Werror=format=]
     2 | printf("[%s] time() yielded %zd\n", where, t);
       |                             ~~^            ~
       |                               |            |
       |                               int          time_t {aka long int}
       |                             %ld
 cc1: all warnings being treated as errors