### PR TITLE
libfaketime.c: wrap timespec_get in TIME_UTC macro

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -196,7 +196,9 @@ static time_t       (*real_time)            (time_t *);
 static int          (*real_ftime)           (struct timeb *);
 static int          (*real_gettimeofday)    (struct timeval *, void *);
 static int          (*real_clock_gettime)   (clockid_t clk_id, struct timespec *tp);
+#ifdef TIME_UTC
 static int          (*real_timespec_get)    (struct timespec *ts, int base);
+#endif
 #ifdef FAKE_INTERNAL_CALLS
 static int          (*real___ftime)           (struct timeb *);
 static int          (*real___gettimeofday)    (struct timeval *, void *);
@@ -2441,6 +2443,7 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp)
 }
 
 
+#ifdef TIME_UTC
 #ifdef MACOS_DYLD_INTERPOSE
 int macos_timespec_get(struct timespec *ts, int base)
 #else
@@ -2475,6 +2478,7 @@ int timespec_get(struct timespec *ts, int base)
   /* return the result to the caller */
   return result;
 }
+#endif
 
 
 /*
@@ -2681,7 +2685,9 @@ static void ftpl_init(void)
   real_lxstat64 =           dlsym(RTLD_NEXT, "__lxstat64");
   real_time =               dlsym(RTLD_NEXT, "time");
   real_ftime =              dlsym(RTLD_NEXT, "ftime");
+#ifdef TIME_UTC
   real_timespec_get =       dlsym(RTLD_NEXT, "timespec_get");
+#endif
 #ifdef FAKE_FILE_TIMESTAMPS
   real_utimes  =            dlsym(RTLD_NEXT, "utimes");
   real_utime   =            dlsym(RTLD_NEXT, "utime");
@@ -4163,7 +4169,9 @@ void do_macos_dyld_interpose(void) {
   DYLD_INTERPOSE(macos_nanosleep, nanosleep);
   DYLD_INTERPOSE(macos_poll, poll);
 #endif
+#ifdef TIME_UTC
   DYLD_INTERPOSE(macos_timespec_get, timespec_get);
+#endif
   DYLD_INTERPOSE(macos_select, select);
 #ifdef FAKE_RANDOM
   DYLD_INTERPOSE(macos_getentropy, getentropy);


### PR DESCRIPTION
Function `timespec_get` is not guaranteed to be declared in MacOS since its standard library is non-conformance to modern standards. Therefore, skip patching `timespec_get` if it is undeclared by the standard library.

The detection of `timespec_get` is based on the conjecture that the macro `TIME_UTC` is only defined when `timespec_get` is declared.

---

This PR is motivated by errors I faced when building on `x86_64-darwin`:
```
libfaketime.c:2345:29: error: use of undeclared identifier 'timespec_get'
  DONT_FAKE_TIME(result = (*timespec_get)(ts, base));
                            ^
libfaketime.c:4022:38: error: use of undeclared identifier 'timespec_get'
  DYLD_INTERPOSE(macos_timespec_get, timespec_get);
                                     ^
```

Typing the error into google yielded this: [1], then I got more information and came up with this by looking at others' bits. [2] [3] [4]

[1]: https://stackoverflow.com/questions/52028083/why-isnt-timespec-get-defined-on-any-c-compiler-on-my-mac
[2]: https://github.com/r-lib/later/pull/129/commits/7437c5022036b9d65e8076f90472fdf073fcd304
[3]: https://android.googlesource.com/platform/prebuilts/clang/host/darwin-x86/+/bc5e2e2c0f6c6c92640340c13c0215c98c557190/clang-r407598/include/c++/v1/ctime#55
[4]: https://reviews.llvm.org/D50799