### PR TITLE
Swapped out pthread_rwlock_xxlock(), which doesn't return if it can't…

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -3602,9 +3602,9 @@ int pthread_cond_init_232(pthread_cond_t *restrict cond, const pthread_condattr_
     struct pthread_cond_monotonic *e = (struct pthread_cond_monotonic*)malloc(sizeof(struct pthread_cond_monotonic));
     e->ptr = cond;
 
-    if (pthread_rwlock_wrlock(&monotonic_conds_lock) != 0) {
-      fprintf(stderr,"can't acquire write monotonic_conds_lock\n");
-      exit(-1);
+    if (pthread_rwlock_trywrlock(&monotonic_conds_lock) != 0) {
+      sched_yield();
+      return EAGAIN;
     }
     HASH_ADD_PTR(monotonic_conds, ptr, e);
     pthread_rwlock_unlock(&monotonic_conds_lock);
@@ -3617,9 +3617,9 @@ int pthread_cond_destroy_232(pthread_cond_t *cond)
 {
   struct pthread_cond_monotonic* e;
 
-  if (pthread_rwlock_wrlock(&monotonic_conds_lock) != 0) {
-    fprintf(stderr,"can't acquire write monotonic_conds_lock\n");
-    exit(-1);
+  if (pthread_rwlock_trywrlock(&monotonic_conds_lock) != 0) {
+    sched_yield();
+    return EBUSY;
   }
   HASH_FIND_PTR(monotonic_conds, &cond, e);
   if (e) {
@@ -3701,9 +3701,9 @@ int pthread_cond_timedwait_common(pthread_cond_t *cond, pthread_mutex_t *mutex, 
 
   if (abstime != NULL)
   {
-    if (pthread_rwlock_rdlock(&monotonic_conds_lock) != 0) {
-      fprintf(stderr,"can't acquire read monotonic_conds_lock\n");
-      exit(-1);
+    if (pthread_rwlock_tryrdlock(&monotonic_conds_lock) != 0) {
+      sched_yield();
+      return EAGAIN;
     }
     HASH_FIND_PTR(monotonic_conds, &cond, e);
     pthread_rwlock_unlock(&monotonic_conds_lock);


### PR DESCRIPTION
… obtain the lock, with pthread_rwlock_xxtrylock() followed by sched yield and error code return. The issue is sometimes a thread calling pthread_cond_init() or pthread_cond_destroy() can't acquire the lock when another thread is waiting on a condition variable notification via pthread_cond_timedwait(), and thus the thread calling pthread_cond_init() or pthread_cond_destroy() end up hanging indefinitely.