### PR TITLE
fix build on recent musl (stat64 compat)

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -23,6 +23,8 @@
 
 #define _GNU_SOURCE             /* required to get RTLD_NEXT defined */
 
+#define _LARGEFILE64_SOURCE 1   /* required for stat64 on musl */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>


### PR DESCRIPTION
musl removed LFS64 compat[1] so stat64 is no longer defined by default, but we can bring it back for now through _LARGEFILE64_SOURCE

Link: https://www.openwall.com/lists/musl/2022/09/26/1 [1]
Fixes: #446

------
Hi & thanks for libfaketime!

#446 ended up in a low "let's just not use alpine 3.19" note but it's easy enough to keep the build working for now, and it also doesn't seem to break on glibc either (running tests seem happy)