### PR TITLE
Draft: Add support for tapered, precise, absolute faketime start time

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -1166,6 +1166,20 @@ static long long faketime_offset_ns()
   return ((long long)user_offset.tv_sec) * 1000000000 + (long long)user_offset.tv_nsec;
 }
 
+// figure out what combination of ifdefs is appropriate, or use
+// this unconditionally
+#if 1
+
+static long long mult_div_avoid_overflow(long long a, long long b, long long d)
+{
+  __int128_t acc = a;
+  acc *= b;
+  acc /= d;
+  return (long long)acc;
+}
+
+#else
+
 // (a * b + c) / d, but do something to avoid multiplication overflow
 // (only "mostly" prevents overflow, not if the values are already
 // over 2^62)
@@ -1194,6 +1208,8 @@ static long long mult_div_avoid_overflow(long long a, long long b, long long d)
   long long res = a / d;
   return res + mad_div_avoid_overflow_inner(a%d, b, 0, d);
 }
+
+#endif
 
 static long long faketime_do_tapered_transform_gen(long long t, long long taper_begin, long long taper_end, long long offset)
 {


### PR DESCRIPTION
`FAKETIME_KEEP_BEFORE_NSEC_SINCE_EPOCH` behaves similar to `FAKETIME_START_AFTER_SECONDS`, with two main differences:

* the timestamp is absolute, instead of being relative to process startup
* the timestamp is specified in nanoseconds

The reason we want this feature is the following use case.

We run a large test suite under faketime. That test suite has access to filesystem artifacts that were created prior to test start up. Among those artifacts are some caches which are considered up to date iff the timestamps of the files match what's recorded in a data structure.

This means that to access those caches to be considered valid we need their timestamps to not be rewritten.

The reason we can't use `FAKETIME_START_AFTER_SECONDS` directly is that the test suite consists of multiple processes, for those processes to correctly interact with each other they need a consistent timestamp mapping that is shared between them. In fact the simplest bash script already behaves incorrectly because the commands use different process start times.

```
touch old
FAKETIME=+100d FAKETIME_START_AFTER_SECONDS=0 bash -c 'touch new; stat old new'
```

The expected behavior is that the timestamp of `old` is not rewritten, while the timestamp of `new` is rewritten.

That is in fact achievable now:

```
touch old
now_ns=$(date +%s.%N | sed -r 's_\.__')
FAKETIME=+100d FAKETIME_KEEP_BEFORE_NSEC_SINCE_EPOCH="$now_ns" bash -c 'touch new; stat old new'
```