### PR TITLE
Add --disable-shm / FAKETIME_DISABLE_SHM

### DIFF
--- a/README
+++ b/README
@@ -486,6 +486,9 @@ for long-running systems (servers with high uptime) and systems on which
 a lot of processes are started (e.g., servers handling many containers
 or similar virtualization mechanisms).
 
+Use of shared memory can be disabled by setting the FAKETIME_DISABLE_SHM
+environment variable, or equivalently, passing --disable-shm to faketime.
+
 
 Intercepting time-setting calls
 -------------------------------

--- a/man/faketime.1
+++ b/man/faketime.1
@@ -32,6 +32,9 @@ use the advanced timestamp specification format.
 \fB\--exclude-monotonic\fR
 Do not fake time when the program makes a call to clock_gettime with a CLOCK_MONOTONIC clock.
 .TP
+\fB\--disable-shm\fR
+Disable use of shared memory by libfaketime.
+.TP
 \fB\--date-prog <PATH>\fR
 Use a specific GNU-date compatible implementation of the helper used to transform "timestamp format" strings into programmatically usable dates, instead of a compile-time default guess for the generic target platform.
 

--- a/src/faketime.c
+++ b/src/faketime.c
@@ -78,6 +78,9 @@ void usage(const char *name)
 #ifdef FAKE_PID
   "  -p PID              : Pretend that the program's process ID is PID\n"
 #endif
+#ifndef FAKE_STATELESS
+  "  --disable-shm       : Disable use of shared memory by libfaketime.\n"
+#endif
   "  --date-prog PROG    : Use specified GNU-compatible implementation of 'date' program\n"
   "\n"
   "Examples:\n"
@@ -150,6 +153,14 @@ int main (int argc, char **argv)
       curr_opt++;
       continue;
     }
+#ifndef FAKE_STATELESS
+    else if (0 == strcmp(argv[curr_opt], "--disable-shm"))
+    {
+      setenv("FAKETIME_DISABLE_SHM", "1", true);
+      curr_opt++;
+      continue;
+    }
+#endif
     else if (0 == strcmp(argv[curr_opt], "--date-prog"))
     {
       curr_opt++;

--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -2790,7 +2790,10 @@ static void ftpl_really_init(void)
 #ifdef FAKE_STATELESS
   if (0) ft_shm_init();
 #else
-  ft_shm_init();
+  tmp_env = getenv("FAKETIME_DISABLE_SHM");
+  if (!tmp_env || tmp_env[0] == '0') {
+    ft_shm_init();
+  }
 #endif
 #ifdef FAKE_STAT
   if (getenv("NO_FAKE_STAT")!=NULL)


### PR DESCRIPTION
The use of shared memory has side effects (triggering `malloc` and causing a deadlock or crash as reported in https://github.com/wolfcw/libfaketime/issues/130#issuecomment-1989773770).

Currently, the only way to opt out of shared memory is by compiling with -DFAKE_STATELESS.

To allow disabling shared memory without recompiling, this patch introduces the --disable-shm option to `faketime`, equivalent to setting the `FAKETIME_DISABLE_SHM=1` environment variable.