### PR TITLE
Check if the user is on ARM64, add target to CFLAGS/LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,23 @@ distclean:
 	$(MAKE) $(SELECTOR) -C src distclean
 	$(MAKE) $(SELECTOR) -C test distclean
 
+macarm64:
+	$(MAKE) $(SELECTOR) -C src clean
+	$(MAKE) $(SELECTOR) -C src distclean
+	$(MAKE) $(SELECTOR) -C src all
+# 	$(MAKE) $(SELECTOR) -C test all
+# 	$(MAKE) $(SELECTOR) -C test distclean
+	$(MAKE) $(SELECTOR) -C src install
+	$(MAKE) $(SELECTOR) -C man install
+	$(INSTALL) -dm0755 "${DESTDIR}${PREFIX}/share/doc/faketime/"
+	$(INSTALL) -m0644 README "${DESTDIR}${PREFIX}/share/doc/faketime/README"
+	$(INSTALL) -m0644 NEWS "${DESTDIR}${PREFIX}/share/doc/faketime/NEWS"
+
+macarm64full:
+	$(MAKE) $(SELECTOR) -C src clean
+	$(MAKE) $(SELECTOR) -C src distclean
+	$(MAKE) $(SELECTOR) -C src all
+	$(MAKE) $(SELECTOR) -C test all
+# 	$(MAKE) $(SELECTOR) -C test distclean
+
 .PHONY: all test install uninstall clean distclean

--- a/src/Makefile.OSX
+++ b/src/Makefile.OSX
@@ -58,6 +58,21 @@ PREFIX ?= /usr/local
 CFLAGS += -DFAKE_SLEEP -DFAKE_INTERNAL_CALLS -DPREFIX='"'${PREFIX}'"' $(FAKETIME_COMPILE_CFLAGS) -DMACOS_DYLD_INTERPOSE -DFAKE_SETTIME
 LIB_LDFLAGS += -dynamiclib -current_version 0.9.10 -compatibility_version 0.7
 
+# ARM64 MacOS (M1/M2/M3/Apple Silicon/etc) processors require a target set as their current version, or they
+# will receive the following error:
+# dyld[6675]: terminating because inserted dylib '/usr/local/lib/faketime/libfaketime.1.dylib' could not be loaded: tried: '/usr/local/lib/faketime/libfaketime.1.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e')), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/lib/faketime/libfaketime.1.dylib' (no such file), '/usr/local/lib/faketime/libfaketime.1.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e'))
+# dyld[6675]: tried: '/usr/local/lib/faketime/libfaketime.1.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e')), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/lib/faketime/libfaketime.1.dylib' (no such file), '/usr/local/lib/faketime/libfaketime.1.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e'))
+# Outputs `arm64` on ARM64
+OS := $(shell uname -m)
+# Outputs a number, eg 14.4 for MacOS Sonoma 14.4
+MACOS_PRODUCT_VERSION := $(shell sw_vers --productVersion | cut -d. -f1,2)
+
+# Check if arm64 is in OS, if so, add the target
+ifeq ($(OS),arm64)
+  CFLAGS += -target arm64e-apple-macos$(MACOS_PRODUCT_VERSION)
+  LIB_LDFLAGS += -target arm64e-apple-macos$(MACOS_PRODUCT_VERSION)
+endif
+
 SONAME = 1
 LIBS = libfaketime.${SONAME}.dylib
 BINS = faketime


### PR DESCRIPTION
Fixes #334

This pull requests adds support for MacOS ARM64, by adding `-target` to the CFLAGS/LDFLAGS.

Without this, the user will receieve the following error:
```sh
dyld[6675]: terminating because inserted dylib '/usr/local/lib/faketime/libfaketime.1.dylib' could not be loaded: tried: '/usr/local/lib/faketime/libfaketime.1.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e')), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/lib/faketime/libfaketime.1.dylib' (no such file), '/usr/local/lib/faketime/libfaketime.1.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e'))
dyld[6675]: tried: '/usr/local/lib/faketime/libfaketime.1.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e')), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/lib/faketime/libfaketime.1.dylib' (no such file), '/usr/local/lib/faketime/libfaketime.1.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e'))

```

The trick seems to be adding `-target arm64e-apple-macos14.4` to `CFLAGS` and `LIB_LDFLAGS`.

So 14.4 is the version of MacOS I'm on:

```sh
$ sw_vers
ProductName:            macOS
ProductVersion:         14.4
BuildVersion:           23E214
```

```sh
uname -a
```
```sh
Darwin joshs-MBP.lan 23.4.0 Darwin Kernel Version 23.4.0: Wed Feb 21 21:45:49 PST 2024; root:xnu-10063.101.15~2/RELEASE_ARM64_T6020 arm64 arm Darwin
```

Showing the version:
```sh
sw_vers --productVersion
```

```sh
14.4
```

Checking if the user is on arm64:
```sh
$ uname -m
```

```sh
arm64
```

So we can just check in the Makefile.OSX if the user is on ARM64, then just add the flag.

You can test this yourself without this patch by appending the `CFLAGS`/`LIB_LDFLAGS` environment variables:

```sh
MACOS_PRODUCT_VERSION=$(sw_vers --productVersion | cut -d. -f1,2)
export CFLAGS="$CFLAGS -target arm64e-apple-macos${MACOS_PRODUCT_VERSION}"
export LIB_LDFLAGS="$LIB_LDFLAGS -target arm64e-apple-macos${MACOS_PRODUCT_VERSION}"
```

Happy for this PR to be altered as you see fit, this issue poked something in my brain and I was curious how to fix it, fun way to spend a lunch :-).