### PR TITLE
Preventing shared semaphore to be used again

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -628,6 +628,7 @@ static void ft_cleanup (void)
   if (shared_sem != NULL)
   {
     sem_close(shared_sem);
+    shared_sem = NULL;
   }
 #ifdef FAKE_PTHREAD
   if (pthread_rwlock_destroy(&monotonic_conds_lock) != 0) {


### PR DESCRIPTION
The shared semaphore is closed but it's not assigned to null. That's required because the logic check the semaphore status if it's not null. For this reason, we are getting a core some times.