### PR TITLE
test/libmallocintercept.c: fix write function unused return value

### DIFF
--- a/test/libmallocintercept.c
+++ b/test/libmallocintercept.c
@@ -24,7 +24,9 @@
 #include <unistd.h>
 
 static void print_msg(const char *msg) {
-	write(0, msg, strlen(msg));
+	size_t out;
+	out = write(0, msg, strlen(msg));
+	(void) out; /* unused */
 }
 
 static void* actual_malloc(size_t size) {


### PR DESCRIPTION
We should ignore the return value for logging function, to fix a new gcc ftbfs libmallocintercept.c: In function ‘print_msg’:
libmallocintercept.c:27:9: error: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’ [-Werror=unused-result]
   27 |         write(0, msg, strlen(msg));
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~