### PR TITLE
Re-disable faking utime by default

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -876,7 +876,7 @@ static bool load_time(struct timespec *tp)
  *      =======================================================================
  */
 #ifdef FAKE_UTIME
-static int fake_utime_disabled = 0;
+static int fake_utime_disabled = 1;
 #endif
 
 


### PR DESCRIPTION
Fixes
  https://github.com/wolfcw/libfaketime/issues/483

We saw this in Debian CI: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1093412#35