### PR TITLE
Fake 64-bit time on 32-bit systems

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -168,7 +168,7 @@ struct utimbuf {
 struct __timespec64
 {
   uint64_t tv_sec;         /* Seconds */
-  uint64_t tv_nsec;        /* Nanoseconds */
+  uint32_t tv_nsec;        /* this is 32-bit, apparently! */
 };
 
 /*

--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -2437,6 +2437,27 @@ int __clock_gettime64(clockid_t clk_id, struct __timespec64 *tp64)
   return result;
 }
 
+/* this is used by 32-bit architectures only */
+uint64_t __time64(uint64_t *write_out)
+{
+  struct timespec tp;
+  uint64_t output;
+  int error;
+
+  error = clock_gettime(CLOCK_REALTIME, &tp);
+  if (error == -1)
+  {
+    return (uint64_t)error;
+  }
+  output = tp.tv_sec;
+
+  if (write_out)
+  {
+    *write_out = output;
+  }
+  return output;
+}
+
 #ifdef TIME_UTC
 #ifdef MACOS_DYLD_INTERPOSE
 int macos_timespec_get(struct timespec *ts, int base)

--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -171,6 +171,13 @@ struct __timespec64
   uint32_t tv_nsec;        /* this is 32-bit, apparently! */
 };
 
+/* __timespec64 is needed for clock_gettime64 on 32-bit architectures */
+struct __timeval64
+{
+  uint64_t tv_sec;         /* Seconds */
+  uint64_t tv_usec;        /* this is 64-bit, apparently! */
+};
+
 /*
  * Per thread variable, which we turn on inside real_* calls to avoid modifying
  * time multiple times of for the whole process to prevent faking time
@@ -2434,6 +2441,18 @@ int __clock_gettime64(clockid_t clk_id, struct __timespec64 *tp64)
   result = clock_gettime(clk_id, &tp);
   tp64->tv_sec = tp.tv_sec;
   tp64->tv_nsec = tp.tv_nsec;
+  return result;
+}
+
+/* this is used by 32-bit architectures only */
+int __gettimeofday64(struct __timeval64 *tv64, void *tz)
+{
+  struct timeval tv;
+  int result;
+
+  result = gettimeofday(&tv, tz);
+  tv64->tv_sec = tv.tv_sec;
+  tv64->tv_usec = tv.tv_usec;
   return result;
 }
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 
-CFLAGS += -std=gnu99 -Wall -DFAKE_STAT -Werror -Wextra $(FAKETIME_COMPILE_CFLAGS)
+CFLAGS += -std=gnu99 -Wall -DFAKE_STAT -Werror -Wextra $(FAKETIME_COMPILE_CFLAGS) -U_FILE_OFFSET_BITS -U_TIME_BITS
 LDFLAGS += -lrt -lpthread
 
 SRC = timetest.c


### PR DESCRIPTION
Hi.  This is an attempt at fixing #418.

The background is that faketime is used quite extensively in Debian, as part of various packages' tests.  Most 32-bit architectures in Debian are now using 64-bit time_t, \[1] and the lack of support in faketime broke those tests.

\[1] The main exception is i386 (aka x86_32) which is still using 32-bit time_t, because the principal use case for that arch is running old proprietary binaries, which obviously can't be updated.

This patch series works in Debian - our CI has confirmed that all the packages which were broken by t64 are now fixed.  (Some race fixes were necessary too - I'm going to make another MR with those.)

Debian is entirely ELF now.  So it is possible that this series won't work on every platform supported by faketime.  Probably, in that case, ifdeffery will be needed.

This series does **not fix #482**.  faketime *still* has a Y2038 bug on 32-bit arches with t64.  #482 didn't seem easy.