### PR TITLE
Fix several data races

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -3690,9 +3690,9 @@ int pthread_cond_init_232(pthread_cond_t *restrict cond, const pthread_condattr_
     struct pthread_cond_monotonic *e = (struct pthread_cond_monotonic*)malloc(sizeof(struct pthread_cond_monotonic));
     e->ptr = cond;
 
-    if (pthread_rwlock_trywrlock(&monotonic_conds_lock) != 0) {
-      sched_yield();
-      return EAGAIN;
+    if (pthread_rwlock_wrlock(&monotonic_conds_lock) != 0) {
+      fprintf(stderr,"can't acquire write monotonic_conds_lock\n");
+      exit(-1);
     }
     HASH_ADD_PTR(monotonic_conds, ptr, e);
     pthread_rwlock_unlock(&monotonic_conds_lock);
@@ -3707,9 +3707,9 @@ int pthread_cond_destroy_232(pthread_cond_t *cond)
 
   ftpl_init();
 
-  if (pthread_rwlock_trywrlock(&monotonic_conds_lock) != 0) {
-    sched_yield();
-    return EBUSY;
+  if (pthread_rwlock_wrlock(&monotonic_conds_lock) != 0) {
+    fprintf(stderr,"can't acquire write monotonic_conds_lock\n");
+    exit(-1);
   }
   HASH_FIND_PTR(monotonic_conds, &cond, e);
   if (e) {
@@ -3793,9 +3793,9 @@ int pthread_cond_timedwait_common(pthread_cond_t *cond, pthread_mutex_t *mutex, 
 
   if (abstime != NULL)
   {
-    if (pthread_rwlock_tryrdlock(&monotonic_conds_lock) != 0) {
-      sched_yield();
-      return EAGAIN;
+    if (pthread_rwlock_rdlock(&monotonic_conds_lock) != 0) {
+      fprintf(stderr,"can't acquire read monotonic_conds_lock\n");
+      exit(-1);
     }
     HASH_FIND_PTR(monotonic_conds, &cond, e);
     pthread_rwlock_unlock(&monotonic_conds_lock);

--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -3705,6 +3705,8 @@ int pthread_cond_destroy_232(pthread_cond_t *cond)
 {
   struct pthread_cond_monotonic* e;
 
+  ftpl_init();
+
   if (pthread_rwlock_trywrlock(&monotonic_conds_lock) != 0) {
     sched_yield();
     return EBUSY;
@@ -3786,6 +3788,8 @@ int pthread_cond_timedwait_common(pthread_cond_t *cond, pthread_mutex_t *mutex, 
   int wait_ms;
   clockid_t clk_id;
   int result = 0;
+
+  ftpl_init();
 
   if (abstime != NULL)
   {

--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -521,16 +521,20 @@ static void ft_shm_destroy(void)
   }
 }
 
+static pthread_once_t ft_shm_initialized_once_control = PTHREAD_ONCE_INIT;
+
+static void ft_shm_really_init (void);
 static void ft_shm_init (void)
+{
+  pthread_once(&ft_shm_initialized_once_control, ft_shm_really_init);
+}
+
+static void ft_shm_really_init (void)
 {
   int ticks_shm_fd;
   char sem_name[256], shm_name[256], *ft_shared_env = getenv("FAKETIME_SHARED");
   sem_t *shared_semR = NULL;
   static int nt=1;
-  static int ft_shm_initialized = 0;
-
-  /* do all of this once only */
-  if (ft_shm_initialized > 0) return;
 
   /* create semaphore and shared memory locally unless it has been passed along */
   if (ft_shared_env == NULL)
@@ -610,8 +614,6 @@ static void ft_shm_init (void)
   { /* force the deletion of the shm sync env variable */
     unsetenv("FAKETIME_SHARED");
   }
-
-  ft_shm_initialized = 1;
 }
 
 static void ft_cleanup (void)


### PR DESCRIPTION
There were several places where the code in `libfaketime.c` used ad-hoc synchronisation (eg for doing the initialisation only once) using non-atomic C variables.  In a multithreaded program, this is not correct.  The C language rules are that data races like this are completely forbidden, and the compiler is allowed to optimise the code using the assumption that such races do not ever occur.

In practice, while trying to fix faketime in Debian trixie, I found that faketime misbehaved in CI, in the test suites of various other packages.  Notably, the Ruby interpreter, but other cases too.  Some cases involved stack traces, and others "impossible" results.  In each case, I examined the output from the test case, and the apparently-relevant code in libfaketime.c.  In each case, I found code in libfaketime.c that seemed to be to be incorrect.  Fixing the data races, by using the correct constructions and the correct primitives, fixed all the tests.

It's likely that the approach I've taken won't compile on some platforms targeted by libfaketime.  I have relied on the existence of pthread_once.  For platforms without pthread_once, there will hopefully be an analogous function.  If there are platforms without an anlogous function, there is an obvious implementation in terms of a mutex, at the cost of some loss of performance.  I would strongly counsel against attempts to open-code using spin locks and atomics, unless the code can be both written, and separately reviewed, by at least two experts in these techniques.  In any case, implementations using ordinary non-atomic variables cannot be correct and will lead to race bugs.  Sorry that I haven't provided support for those other platforms.

I think the final patch "Don't use _try_ locking calls for monotonic_conds_lock" will fix #464.

Together with #487 and #486, these race fixes fix the CI failures with packages' test suites, in Debian.