### PR TITLE
missing FUTEX_CLOCK_REALTIME declaration when build with flags -DINTERCEPT_SYSCALL -DINTERCEPT_FUTEX

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -59,6 +59,9 @@
 #ifdef __linux__
 #include <stdarg.h>
 #include <sys/syscall.h>
+#ifdef INTERCEPT_FUTEX
+#include <linux/futex.h>
+#endif
 #else
 #error INTERCEPT_SYSCALL should only be defined on GNU/Linux systems.
 #endif


### PR DESCRIPTION
build fail with appended flags -DINTERCEPT_SYSCALL -DINTERCEPT_FUTEX noted in #493 

```shell
$ sudo make
make  -C src all
make[1]: Entering directory '/home/piotrbz/libfaketime/src'
cc -o libfaketime.o -c -std=gnu99 -Wall -Wextra -Werror -DFAKE_PTHREAD -DDEBUG -DFAKE_STAT -DFAKE_UTIME -DFAKE_SLEEP -DFAKE_TIMERS -DFAKE_INTERNAL_CALLS -DINTERCEPT_SYSCALL -DINTERCEPT_FUTEX -fPIC -DPREFIX='"'/usr/local'"' -DLIBDIRNAME='"'/lib/faketime'"'  -Wno-nonnull-compare   libfaketime.c
libfaketime.c: In function ‘handle_futex_syscall’:
libfaketime.c:4199:20: error: ‘FUTEX_CLOCK_REALTIME’ undeclared (first use in this function); did you mean ‘CLOCK_REALTIME’?
 4199 |     if (futex_op & FUTEX_CLOCK_REALTIME)
      |                    ^~~~~~~~~~~~~~~~~~~~
      |                    CLOCK_REALTIME
libfaketime.c:4199:20: note: each undeclared identifier is reported only once for each function it appears in
make[1]: *** [Makefile:162: libfaketime.o] Error 1
make[1]: Leaving directory '/home/piotrbz/libfaketime/src'
make: *** [Makefile:8: all] Error 2
```
```shell
$ uname -a
Linux k21049859 5.15.167.4-microsoft-standard-WSL2 #1 SMP Tue Nov 5 00:21:55 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux
```

