### PR TITLE
Compile for arm64 on darwin again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,23 +33,4 @@ distclean:
 	$(MAKE) $(SELECTOR) -C src distclean
 	$(MAKE) $(SELECTOR) -C test distclean
 
-macarm64:
-	$(MAKE) $(SELECTOR) -C src clean
-	$(MAKE) $(SELECTOR) -C src distclean
-	$(MAKE) $(SELECTOR) -C src all
-# 	$(MAKE) $(SELECTOR) -C test all
-# 	$(MAKE) $(SELECTOR) -C test distclean
-	$(MAKE) $(SELECTOR) -C src install
-	$(MAKE) $(SELECTOR) -C man install
-	$(INSTALL) -dm0755 "${DESTDIR}${PREFIX}/share/doc/faketime/"
-	$(INSTALL) -m0644 README "${DESTDIR}${PREFIX}/share/doc/faketime/README"
-	$(INSTALL) -m0644 NEWS "${DESTDIR}${PREFIX}/share/doc/faketime/NEWS"
-
-macarm64full:
-	$(MAKE) $(SELECTOR) -C src clean
-	$(MAKE) $(SELECTOR) -C src distclean
-	$(MAKE) $(SELECTOR) -C src all
-	$(MAKE) $(SELECTOR) -C test all
-# 	$(MAKE) $(SELECTOR) -C test distclean
-
 .PHONY: all test install uninstall clean distclean

--- a/src/Makefile.OSX
+++ b/src/Makefile.OSX
@@ -58,6 +58,18 @@ PREFIX ?= /usr/local
 CFLAGS += -DFAKE_SLEEP -DFAKE_INTERNAL_CALLS -DPREFIX='"'${PREFIX}'"' $(FAKETIME_COMPILE_CFLAGS) -DMACOS_DYLD_INTERPOSE -DFAKE_SETTIME
 LIB_LDFLAGS += -dynamiclib -current_version 0.9.11 -compatibility_version 0.7
 
+# From macOS 13 onwards, system binaries are compiled against the new arm64e ABI on Apple Silicon.
+# These arm64e binaries enforce Pointer Authentication Code (PAC), and will refuse to run with
+# "unprotected" arm64 libraries. Meanwhile, older platforms might not recognize the new arm64e ABI.
+
+# Therefore, we now compile for two ABIs at the same time, producing a fat library of arm64e and arm64,
+# so in the end the OS gets to pick which architecture it wants at runtime.
+ARCH := $(shell uname -m)
+
+ifeq ($(ARCH),arm64)
+    CFLAGS += -arch arm64e -arch arm64
+endif
+
 SONAME = 1
 LIBS = libfaketime.${SONAME}.dylib
 BINS = faketime

--- a/src/Makefile.OSX
+++ b/src/Makefile.OSX
@@ -58,21 +58,6 @@ PREFIX ?= /usr/local
 CFLAGS += -DFAKE_SLEEP -DFAKE_INTERNAL_CALLS -DPREFIX='"'${PREFIX}'"' $(FAKETIME_COMPILE_CFLAGS) -DMACOS_DYLD_INTERPOSE -DFAKE_SETTIME
 LIB_LDFLAGS += -dynamiclib -current_version 0.9.11 -compatibility_version 0.7
 
-# ARM64 MacOS (M1/M2/M3/Apple Silicon/etc) processors require a target set as their current version, or they
-# will receive the following error:
-# dyld[6675]: terminating because inserted dylib '/usr/local/lib/faketime/libfaketime.1.dylib' could not be loaded: tried: '/usr/local/lib/faketime/libfaketime.1.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e')), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/lib/faketime/libfaketime.1.dylib' (no such file), '/usr/local/lib/faketime/libfaketime.1.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e'))
-# dyld[6675]: tried: '/usr/local/lib/faketime/libfaketime.1.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e')), '/System/Volumes/Preboot/Cryptexes/OS/usr/local/lib/faketime/libfaketime.1.dylib' (no such file), '/usr/local/lib/faketime/libfaketime.1.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'arm64e'))
-# Outputs `arm64` on ARM64
-OS := $(shell uname -m)
-# Outputs a number, eg 14.4 for MacOS Sonoma 14.4
-MACOS_PRODUCT_VERSION := $(shell sw_vers --productVersion | cut -d. -f1,2)
-
-# Check if arm64 is in OS, if so, add the target
-ifeq ($(OS),arm64)
-  CFLAGS += -target arm64e-apple-macos$(MACOS_PRODUCT_VERSION)
-  LIB_LDFLAGS += -target arm64e-apple-macos$(MACOS_PRODUCT_VERSION)
-endif
-
 SONAME = 1
 LIBS = libfaketime.${SONAME}.dylib
 BINS = faketime


### PR DESCRIPTION
There are two/three major issues on release 0.9.11 that broke `libfaketime` on macOS.

- https://github.com/wolfcw/libfaketime/pull/466 actually removed support for `arm64`, which is still very important for older darwin releases not aware of the newer `arm64e` to work, evident in https://github.com/wolfcw/libfaketime/pull/466#issuecomment-2016894510.

- Nitpick: It uses an unnecessary product version whereas it could be as simple as `-arch arm64e`. It adds a confusing error message instead of a proper explanation. It disables the test to fool itself that it is working, but the resulting `.dylib` for `arm64e` is still not functional.

- Why not functional? Apple silently compiled all its system binaries against the new `arm64e` ABI since some months ago, and at the same time forbid third-party `arm64e` code by locking it behind SIP and `nvram boot-args=-arm64e_preview_abi`. And EVEN IF you manage to jump through these hoops, hooking in the library will still fail (seen from the Console app):

  ```
  Exception Type:        EXC_BAD_ACCESS (SIGKILL)
  Exception Codes:       KERN_INVALID_ADDRESS at 0xe63f0001856f30f8 -> 0x00000001856f30f8 (possible pointer authentication failure)
  Exception Codes:       0x0000000000000001, 0xe63f0001856f30f8

  Termination Reason:    Namespace PAC_EXCEPTION, Code 1 

  VM Region Info: 0x1856f30f8 is in 0x1856f0000-0x185720000;  bytes after start: 12536  bytes before end: 184071
        REGION TYPE                    START - END         [ VSIZE] PRT/MAX SHRMOD  REGION DETAIL
        __TEXT                      1856e3000-1856f0000    [   52K] r-x/r-x SM=COW  /usr/lib/system/libsystem_pthread.dylib
  --->  __TEXT                      1856f0000-185720000    [  192K] r-x/r-x SM=COW  /usr/lib/system/libdyld.dylib
        __TEXT                      185720000-185728000    [   32K] r-x/r-x SM=COW  /usr/lib/system/libsystem_platform.dylib
  ```

- I am not saying we should not support `arm64e`, but it should NOT break `arm64`, especially when it is still not functional. This PR reverts the first PR and compiles for _both_ `arm64` and `arm64e`, so while `arm64e` doesn't quite work yet, nothing should affect the build working on original `arm64`-built systems.

- More information on the new `arm64e` ABI can be found here: https://github.com/lelegard/arm-cpusysregs/blob/main/docs/arm64e-on-macos.md

---

Note: This PR won't fix building on darwin on its own. Another problem is that commit https://github.com/wolfcw/libfaketime/pull/488/commits/2503b0fffc19268396dbf4fa60071e1e04ef9908 in https://github.com/wolfcw/libfaketime/pull/488 caused a regression on darwin, on both `arm64e` and `arm64`. More info can be seen at the Console app:
```
Termination Reason:    Namespace SIGNAL, Code 5 Trace/BPT trap: 5
Terminating Process:   exc handler [41707]

Application Specific Information:
BUG IN CLIENT OF LIBPLATFORM: Trying to recursively lock an os_once_t
Abort Cause 259
```

And this is a comment in commit https://github.com/wolfcw/libfaketime/pull/488/commits/2503b0fffc19268396dbf4fa60071e1e04ef9908 which basically confirmed that this could happen.
```
// If ftpl_init ends up recursing, pthread_once will deadlock.
// (Previously we attempted to detect this situation, and bomb out,
// but the approach taken wasn't thread-safe and broke in practice.)
```

Reverting the commit works, but will break the Debian tests again. I am still understanding and trying different ways to fix this, but I hope to get this PR in first.

Thanks for reading. 🙏 