### PR TITLE
Fix darwin and arm64e

### DIFF
--- a/src/Makefile.OSX
+++ b/src/Makefile.OSX
@@ -64,10 +64,16 @@ LIB_LDFLAGS += -dynamiclib -current_version 0.9.11 -compatibility_version 0.7
 
 # Therefore, we now compile for two ABIs at the same time, producing a fat library of arm64e and arm64,
 # so in the end the OS gets to pick which architecture it wants at runtime.
+
+# In addition, we need to enable signing and authentication of indirect calls (-fptrauth-calls);
+# otherwise in ftpl_init, pthread_once will indirectly call ftpl_really_init, which then fail PAC.
+# Ideally this should be a compiler default for the arm64e ABI, but apparently not.
+
 ARCH := $(shell uname -m)
 
 ifeq ($(ARCH),arm64)
     CFLAGS += -arch arm64e -arch arm64
+    CFLAGS += -fptrauth-calls -fptrauth-returns
 endif
 
 SONAME = 1

--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -236,7 +236,7 @@ static int          (*real_pthread_cond_destroy_232) (pthread_cond_t *);
 static pthread_rwlock_t monotonic_conds_lock;
 #endif
 
-#ifndef __APPLEOSX__
+#ifndef __APPLE__
 #ifdef FAKE_TIMERS
 static int          (*real_timer_settime_22)   (int timerid, int flags, const struct itimerspec *new_value,
                                                 struct itimerspec * old_value);
@@ -282,7 +282,7 @@ static int          (*real_pselect)         (int nfds, fd_set *restrict readfds,
 static int          (*real_sem_timedwait)   (sem_t*, const struct timespec*);
 static int          (*real_sem_clockwait)   (sem_t *sem, clockid_t clockid, const struct timespec *abstime);
 #endif
-#ifdef __APPLEOSX__
+#ifdef __APPLE__
 static int          (*real_clock_get_time)  (clock_serv_t clock_serv, mach_timespec_t *cur_timeclockid_t);
 static int          apple_clock_gettime     (clockid_t clk_id, struct timespec *tp);
 static clock_serv_t clock_serv_real;
@@ -694,7 +694,7 @@ static void get_fake_monotonic_setting(int* current_value)
 /* Get system time from system for all clocks */
 static void system_time_from_system (struct system_time_s * systime)
 {
-#ifdef __APPLEOSX__
+#ifdef __APPLE__
   /* from https://stackoverflow.com/questions/5167269/clock-gettime-alternative-in-mac-os-x */
   clock_serv_t cclock;
   mach_timespec_t mts;
@@ -2784,7 +2784,7 @@ static void ftpl_really_init(void)
     exit(-1);
   }
 #endif
-#ifdef __APPLEOSX__
+#ifdef __APPLE__
   real_clock_get_time =     dlsym(RTLD_NEXT, "clock_get_time");
   real_clock_gettime  =     apple_clock_gettime;
 #else
@@ -3545,7 +3545,7 @@ int fake_gettimeofday(struct timeval *tv)
  *      =======================================================================
  */
 
-#ifdef __APPLEOSX__
+#ifdef __APPLE__
 /*
  * clock_gettime implementation for __APPLE__
  * @note It always behave like being called with CLOCK_REALTIME.


### PR DESCRIPTION
Follow up to https://github.com/wolfcw/libfaketime/pull/497, these changes should hopefully un-break darwin. 🤞

Closes https://github.com/wolfcw/libfaketime/issues/498 

## Demo

```sh
$ /usr/bin/file $(which /bin/date)
/bin/date: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64e:Mach-O 64-bit executable arm64e]
/bin/date (for architecture x86_64):	Mach-O 64-bit executable x86_64
/bin/date (for architecture arm64e):	Mach-O 64-bit executable arm64e
$ /usr/bin/file $(which date)
/nix/store/d72z8b7fvvcin2p84x7h5s0abkggplzc-coreutils-9.7/bin/date: Mach-O 64-bit executable arm64

$ FAKETIME="2020-12-24 20:30:00" DYLD_INSERT_LIBRARIES=./src/libfaketime.1.dylib /bin/date
Thu 24 Dec 2020 20:30:00 HKT
$ FAKETIME="2020-12-24 20:30:00" DYLD_INSERT_LIBRARIES=./src/libfaketime.1.dylib date
Thu Dec 24 20:30:00 HKT 2020
```

Two versions of `date` here, `/bin/date` is the system version compiled in `arm64e`; and the regular `date` is the `nix` / `coreutils` version in my `$PATH`, compiled in `arm64`. Both should work now.

Edit: I am running a `sudo nvram boot-args=-arm64e_preview_abi` and `csrutil disable`-ed setup.

## Fixing the recursive pthread_once deadlock

Previously at https://github.com/wolfcw/libfaketime/pull/497, I mentioned this commit https://github.com/wolfcw/libfaketime/pull/488/commits/2503b0fffc19268396dbf4fa60071e1e04ef9908 from https://github.com/wolfcw/libfaketime/pull/488 caused a regression:

```
Application Specific Information:
BUG IN CLIENT OF LIBPLATFORM: Trying to recursively lock an os_once_t
Abort Cause 259
```
```c
// If ftpl_init ends up recursing, pthread_once will deadlock.
// (Previously we attempted to detect this situation, and bomb out,
// but the approach taken wasn't thread-safe and broke in practice.)
```

That commit is correct and does what it was intended to do. `pthread_once()` is always meant to deadlock a process when it is called in the same thread twice. It unmasked an error that was under our nose the whole time, but ass-covered by that ad-hoc recursion detection.

The sad truth is that we have been using the incorrect `__APPLEOSX__` all along. And because `__APPLEOSX__` is never defined and that code path is always dead, in `system_time_from_system()` we have been taking the Linux code path on Darwin and called `ftpl_init` when running `ftpl_init`... which is obviously not correct.

```c
static void system_time_from_system (struct system_time_s * systime)
{
#ifdef __APPLEOSX__  // ← INCORRECT: Should be __APPLE__; our lovely code below becomes no-op
  /* macOS-specific code using real_clock_get_time */
#else
  DONT_FAKE_TIME((*real_clock_gettime)(CLOCK_REALTIME, &systime->real));  // ← This gets executed on macOS instead x.x
#endif
}
```

Prove that `__APPLEOSX__` is not a thing:

```
$ echo | clang -dM -E - | grep 'APPLE'
#define __APPLE_CC__ 6000
#define __APPLE__ 1
```

Anyway, that resulted in this backtrace, notice `ftpl_init` in frame `#12` eventually calls itself again in frame `#4`, and as a result `pthread_once` is called twice in frame `#3` and `#11`.

```
(lldb) bt all
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BREAKPOINT (code=1, subcode=0x1912feb24)
  * frame #0: 0x00000001912feb24 libsystem_platform.dylib`_os_once_gate_recursive_abort + 36
    frame #1: 0x00000001912faa98 libsystem_platform.dylib`_os_once_gate_wait + 344
    frame #2: 0x00000001912f8a8c libsystem_platform.dylib`_os_once + 76
    frame #3: 0x00000001912bdb00 libsystem_pthread.dylib`pthread_once + 100
    frame #4: 0x00000001001a05f0 libfaketime.1.dylib`ftpl_init at libfaketime.c:3086:3
    frame #5: 0x00000001001a3260 libfaketime.1.dylib`macos_clock_gettime(clk_id=_CLOCK_REALTIME, tp=0x00000001001ac030) at libfaketime.c:2371:3
    frame #6: 0x00000001001a5dd4 libfaketime.1.dylib`system_time_from_system(systime=0x00000001001ac030) at libfaketime.c:713:3
    frame #7: 0x00000001001a4394 libfaketime.1.dylib`ftpl_really_init at libfaketime.c:3053:7
    frame #8: 0x00000001912bdb64 libsystem_pthread.dylib`__pthread_once_handler + 72
    frame #9: 0x00000001912f8ab8 libsystem_platform.dylib`_os_once_callout + 32
    frame #10: 0x00000001912f8a8c libsystem_platform.dylib`_os_once + 76
    frame #11: 0x00000001912bdb00 libsystem_pthread.dylib`pthread_once + 100
    frame #12: 0x00000001001a05f0 libfaketime.1.dylib`ftpl_init at libfaketime.c:3086:3
```

## Fixing the PAC failure

After the previous fix, the `arm64` build works, but `arm64e` will still fail in `lldb`:

```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0xc51a800100057538)
Note: Possible pointer authentication failure detected.
Found authenticated indirect branch at address=0x1912bdb60.
```

```
(lldb) bt
  * frame #0: 0x0000000100057538 libfaketime.1.dylib`ftpl_really_init at libfaketime.c:2665
    frame #1: 0x00000001912bdb64 libsystem_pthread.dylib`__pthread_once_handler + 72
    [...]

(lldb) disass --start-address 0x00000001912bdb64-8 -c 3
libsystem_pthread.dylib`__pthread_once_handler:
    0x1912bdb5c <+64>: stur   x8, [x20, #-0xd8]
    0x1912bdb60 <+68>: blraaz x9
    0x1912bdb64 <+72>: ldr    x8, [sp, #0x18]

(lldb) disass --start-address 0x0000000100057538-8 -c 5
libfaketime.1.dylib`macos_timespec_get:
    0x100057530 <+284>: mov    x9, #0x0 ; =0
    0x100057534 <+288>: ret

libfaketime.1.dylib`ftpl_really_init:
->  0x100057538 <+0>:   sub    sp, sp, #0x150
    0x10005753c <+4>:   stp    x28, x27, [sp, #0x130]
    0x100057540 <+8>:   stp    x29, x30, [sp, #0x140]
```

We know the error is a PAC failure, and `blraaz` is PAC instruction. So we conclude the error happens when `pthread_once` is trying to call `ftpl_really_init`, here:

```c
inline static void ftpl_init(void) {
  pthread_once(&initialized_once_control, ftpl_really_init);
}
```

It turns out that, it is an indirect call not covered by compiler by default and was unsigned; but then the `arm64e` ABI mandates PAC on everything, so hence the failure. And we know we are in the right here because there are no pointer manipulations here. PAC should not fail.

Andddd turns out there are specific pointer authentication options in the clang reference (https://clang.llvm.org/docs/ClangCommandLineReference.html), and in particular this one:

> - -fptrauth-calls, -fno-ptrauth-calls
> Enable signing and authentication of all indirect calls

We throw this in the Makefile, and it works like magic again.

## Notes

Beware though, for `arm64e` to work on darwin we still need to `sudo nvram boot-args=-arm64e_preview_abi` and disable SIP. That is because running Apple-signed `arm64e` stuff is fine, but running third-party stuff is not. And preloading a third-party `arm64e` library before Apple's `arm64e` binaries definitely falls in the "third-party stuff" area.

Maybe I should update `README.OSX` about that?