### PR TITLE
Fix MONOTONIC pthread_cond_timedwait when REALTIME is set

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -3889,7 +3889,14 @@ int pthread_cond_timedwait_common(pthread_cond_t *cond, pthread_mutex_t *mutex, 
     }
     else
     {
-      timespecsub(abstime, &faketime, &tp);
+      if (!fake_monotonic_clock && clk_id == CLOCK_MONOTONIC)
+      {
+        timespecsub(abstime, &realtime, &tp);
+      }
+      else
+      {
+        timespecsub(abstime, &faketime, &tp);
+      }
       if (user_rate_set)
       {
         timespecmul(&tp, 1.0 / user_rate, &tdiff_actual);


### PR DESCRIPTION
In an application where a thread sets CLOCK_REALTIME with a server time, and another thread uses CLOCK_MONOTONIC for timeouts, it was found that CLOCK_MONOTONIC was being updated as well, thus FAKETIME_DONT_FAKE_MONOTONIC=1 was added when starting the application.

However, it was found that if the thread using CLOCK_MONOTONIC called pthread_cond_timedwait and the other thread set CLOCK_REALTIME, the blocking call would time out early. This is because even though the real CLOCK_MONOTONIC is specified, pthread_cond_timedwait_common was still referencing faketime.