### PR TITLE
Handle stat64() call

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -224,6 +224,7 @@ static int          (*real_fxstat)          (int, int, struct stat *);
 static int          (*real_fxstatat)        (int, int, const char *, struct stat *, int);
 static int          (*real_lxstat)          (int, const char *, struct stat *);
 #if !defined(__APPLE__) || !__DARWIN_ONLY_64_BIT_INO_T
+static int          (*real_stat64)          (const char *, struct stat64 *);
 static int          (*real_xstat64)         (int, const char *, struct stat64 *);
 static int          (*real_fxstat64)        (int, int , struct stat64 *);
 static int          (*real_fxstatat64)      (int, int , const char *, struct stat64 *, int);
@@ -1270,6 +1271,11 @@ int __fxstatat(int ver, int fildes, const char *filename, struct stat *buf, int 
 int __lxstat (int ver, const char *path, struct stat *buf)
 {
   STAT_HANDLER(lxstat, buf, ver, path, buf);
+}
+
+int stat64 (const char *path, struct stat64 *buf)
+{
+  STAT64_HANDLER(stat64, buf, path, buf);
 }
 
 /* Contributed by Philipp Hachtmann in version 0.6 */
@@ -2840,6 +2846,7 @@ static void ftpl_really_init(void)
   real_fxstatat =           dlsym(RTLD_NEXT, "__fxstatat");
   real_lxstat =             dlsym(RTLD_NEXT, "__lxstat");
 #if !defined(__APPLE__) || !__DARWIN_ONLY_64_BIT_INO_T
+  real_stat64 =             dlsym(RTLD_NEXT, "stat64");
   real_xstat64 =            dlsym(RTLD_NEXT,"__xstat64");
   real_fxstat64 =           dlsym(RTLD_NEXT, "__fxstat64");
   real_fxstatat64 =         dlsym(RTLD_NEXT, "__fxstatat64");


### PR DESCRIPTION
This fixes missing modification of timestamps in stat() calls for programs built with large file support (-D_FILE_OFFSET_BITS=64), both 32- and 64-bit.

Demo code:

```
  $ cat <<EOF >test.c
  #include <sys/stat.h>
  int main()
  {
      struct stat buf;
      return stat("/", &buf);
  }
  EOF
```

32-bit build:

```
  $ nix-shell -p gcc --argstr system i686-linux

  nix-shell$ gcc test.c && ltrace ./a.out
  __libc_start_main([ "./a.out" ] <unfinished ...>
  stat(0x804a008, 0xffa4b644, 895, 0) = 0
  +++ exited (status 0) +++

  nix-shell$ gcc -D_FILE_OFFSET_BITS=64 test.c && ltrace ./a.out
  __libc_start_main([ "./a.out" ] <unfinished ...>
  stat64(0x804a008, 0xffdcf61c, 100, 0xffdcfaeb) = 0
  +++ exited (status 0) +++

  nix-shell$ file a.out
  a.out: ELF 32-bit LSB executable, Intel 80386, [...]
```

64-bit build:

```
  $ nix-shell -p gcc

  nix-shell$ gcc test.c && ltrace ./a.out
  stat(0x402004, 0x7ffc50a9d740, 0x7ffc50a9d908, 0x403db0) = 0
  +++ exited (status 0) +++

  nix-shell$ gcc -D_FILE_OFFSET_BITS=64 test.c && ltrace ./a.out
  stat64(0x402004, 0x7ffd5cbafba0, 0x7ffd5cbafd68, 0x403db0) = 0
  +++ exited (status 0) +++

  nix-shell$ file a.out
  a.out: ELF 64-bit LSB executable, x86-64, [...]
```