### PR TITLE
Only define stat64 when building with glibc

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -1273,10 +1273,12 @@ int __lxstat (int ver, const char *path, struct stat *buf)
   STAT_HANDLER(lxstat, buf, ver, path, buf);
 }
 
+#ifdef __GLIBC__
 int stat64 (const char *path, struct stat64 *buf)
 {
   STAT64_HANDLER(stat64, buf, path, buf);
 }
+#endif
 
 /* Contributed by Philipp Hachtmann in version 0.6 */
 int __xstat64 (int ver, const char *path, struct stat64 *buf)


### PR DESCRIPTION
musl defines stat64 as stat, leading to this build error:

```
  gcc -o libfaketime.o -c -std=gnu99 -Wall -Wextra -Werror -DFAKE_PTHREAD -DFAKE_STAT -DFAKE_UTIME -DFAKE_SLEEP -DFAKE_TIMERS -DFAKE_INTERNAL_CALLS -fPIC -DPREFIX='"'/nix/store/qpyvvrcas950da98mssw6ixlw7ckvyrb-libfaketime-0.9.11'"' -DLIBDIRNAME='"'/lib'"'  -Wno-nonnull-compare   libfaketime.c
  In file included from libfaketime.c:55:
  libfaketime.c:1276:5: error: redefinition of ‘stat’
   1276 | int stat64 (const char *path, struct stat64 *buf)
        |     ^~~~~~
  /nix/store/g9cgi4yyn5vrd1f9axj8gxdvwzv5ssvk-musl-1.2.5-dev/include/sys/stat.h:80:5: note: previous definition of ‘stat’ with type ‘int(const char *, struct stat *)’
     80 | int stat(const char *__restrict, struct stat *__restrict);
        |     ^~~~
  make[1]: *** [Makefile:161: libfaketime.o] Error 1
```

Fix it by only defining stat64 when building against glibc, since it's not straight forward to detect musl, and it's the safest approach; there might be other libc implementations that behave like musl.

Fixes: 53ba71e5471d5b49d3cafe0a0f301a40598b8e6b ("Handle stat64() call")