### PR TITLE
Honour CC in test Makefile

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,4 +1,4 @@
-CC = gcc
+CC ?= gcc
 
 CFLAGS += -std=gnu99 -Wall -DFAKE_STAT -Werror -Wextra $(FAKETIME_COMPILE_CFLAGS) -U_FILE_OFFSET_BITS -U_TIME_BITS
 LDFLAGS += -lrt -lpthread


### PR DESCRIPTION
When building with `clang` the test suite still tries to use `gcc`. This PR allows `CC` to be overridden.