### PR TITLE
Use correct result type for clock_gettime

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -2498,7 +2498,7 @@ time_t time(time_t *time_tptr)
 #endif
 {
   struct timespec tp;
-  time_t result;
+  int result;
 
   ftpl_init();
 #ifdef MACOS_DYLD_INTERPOSE
@@ -3960,7 +3960,7 @@ int __clock_gettime(clockid_t clk_id, struct timespec *tp)
 time_t __time(time_t *time_tptr)
 {
   struct timespec tp;
-  time_t result;
+  int result;
 
   DONT_FAKE_TIME(result = (*real_clock_gettime)(CLOCK_REALTIME, &tp));
   if (result == -1) return -1;


### PR DESCRIPTION
`man 2 clock_gettime` says
```
  int clock_gettime(clockid_t clockid, struct timespec *tp);
  clock_gettime() ... return 0 for success.  On error, -1 is returned
  and errno is set to indicate the error.
```

This patch avoids build-failures from `-Werror` and the experimental [`-Wtime_t-conversion` flag](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96570) I test in openSUSE.