### PR TITLE
fix compiling without FAKE_STAT or FAKE_UTIME

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -1291,7 +1291,6 @@ int __lxstat64 (int ver, const char *path, struct stat64 *buf)
 }
 #endif /* __ANDROID__ */
 #endif  /* ifndef __APPLE__ */
-#endif  /* ifdef FAKE_STAT */
 
 #ifdef STATX_TYPE
 static inline void fake_statx_timestamp(struct statx_timestamp* p)
@@ -1324,6 +1323,7 @@ int statx(int dirfd, const char *pathname, int flags, unsigned int mask, struct 
   STAT_HANDLER_COMMON(statx, statxbuf, fake_statxbuf, dirfd, pathname, flags, mask, statxbuf)
 }
 #endif
+#endif  /* ifdef FAKE_STAT */
 
 #ifdef FAKE_FILE_TIMESTAMPS
 #ifdef MACOS_DYLD_INTERPOSE

--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -364,8 +364,10 @@ static pthread_once_t initialized_once_control = PTHREAD_ONCE_INIT;
 /* prototypes */
 static int    fake_gettimeofday(struct timeval *tv);
 static int    fake_clock_gettime(clockid_t clk_id, struct timespec *tp);
+#ifdef FAKE_FILE_TIMESTAMPS
 static int    fake_current_realtime(struct timespec *tp);
 static int    fake_current_timeval(struct timeval *tv);
+#endif
 int           read_config_file();
 bool          str_array_contains(const char *haystack, const char *needle);
 void *ft_dlvsym(void *handle, const char *symbol, const char *version, const char *full_name, char *ignore_list, bool should_debug_dlsym);


### PR DESCRIPTION
Two spots break the build when those macros are undefined: the statx handler added in 942b30e is guarded by STATX_TYPE alone but calls lock_for_stat() and STAT_HANDLER_COMMON, and the fake_current_realtime and fake_current_timeval prototypes are unguarded while their definitions sit under FAKE_FILE_TIMESTAMPS.