### PR TITLE
Fix data race on the user_faked_time buffer

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -3513,7 +3513,7 @@ static void pthread_cleanup_mutex_lock(void *data)
 
 int read_config_file()
 {
-  static char user_faked_time[BUFFERLEN]; /* changed to static for caching in v0.6 */
+  char user_faked_time[BUFFERLEN];
   static char custom_filename[BUFSIZ];
   static char filename[BUFSIZ];
   int faketimerc;
@@ -3681,7 +3681,7 @@ int fake_clock_gettime(clockid_t clk_id, struct timespec *tp)
 
   if (cache_expired == 1)
   {
-    static char user_faked_time[BUFFERLEN]; /* changed to static for caching in v0.6 */
+    char user_faked_time[BUFFERLEN];
     /* initialize with default or env. variable */
     char *tmp_env;
 


### PR DESCRIPTION
When `FAKETIME` is unset the buffer gets the `+0` offset, otherwise the timestamp:

https://github.com/wolfcw/libfaketime/blob/d79bf0ff80f97900b339bead46590b474abd4b62/src/libfaketime.c#L3692-L3700

`parse_ft_string()` then selects its branch from `user_faked_time[0]`, and reads the buffer a second time in `strptime()`:

https://github.com/wolfcw/libfaketime/blob/d79bf0ff80f97900b339bead46590b474abd4b62/src/libfaketime.c#L2766-L2772

The buffer is `static`, so another thread can replace a timestamp with `+0` between those two reads. A `+0` could never reach the absolute branch otherwise, it would have gone to `case '+'`:

    libfaketime: In parse_ft_string(), failed to parse FAKETIME timestamp.
    Please check specification +0 with format %Y-%m-%d %T

Both buffers are always written before being read, so nothing is carried over between calls. The caching is done by `cache_expired` and `user_faked_time_saved`, not by the buffers themselves, so making them local is enough.

Found with [python-libfaketime](https://github.com/simon-weber/python-libfaketime), on a pytest-xdist suite where workers died at random on unrelated tests.