### PR TITLE
libfaketime.c: do not declare __time64 when -D_TIME_BITS=64 is used

### DIFF
--- a/src/libfaketime.c
+++ b/src/libfaketime.c
@@ -1802,10 +1802,12 @@ int __lxstat (int ver, const char *path, struct stat *buf)
 #endif
 
 #ifdef __GLIBC__
+#if (_TIME_BITS != 64)
 int stat64 (const char *path, struct stat64 *buf)
 {
   STAT64_HANDLER(stat64, buf, path, buf);
 }
+#endif
 #endif
 
 /* Contributed by Philipp Hachtmann in version 0.6 */
@@ -3375,7 +3377,7 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp)
 
 #ifdef __GLIBC__
 /* This is used by glibc 32-bit architectures only. */
-#ifndef FAKETIME_TIME64_BUILD
+#if (_TIME_BITS != 64)
 int __clock_gettime64(clockid_t clk_id, struct __timespec64 *tp64)
 {
   struct timespec tp;


### PR DESCRIPTION
When _TIME_BITS macro is set to 64, __clock_gettime64(), __gettimeofday64(), __time64() and stat64() will be defined in the glibc. There is no need to define these here.

Today, we filter on FAKETIME_TIME64_BUILD, but some platform will use -D_TIME_BITS=64 on all builds.